### PR TITLE
lib/manx-utils

### DIFF
--- a/pkg/arvo/neo/src/std/con/diary-htmx.hoon
+++ b/pkg/arvo/neo/src/std/con/diary-htmx.hoon
@@ -12,8 +12,9 @@
     =hx-target  "this"
     =hx-swap  "afterend"
     =head  "put-entry"
-    ;date-now;
+    ;date-now(name "id");
     ;textarea.p2.border.br1
+      =name  "text"
       =placeholder  ". . . text"
       =oninput  "this.setAttribute('value', this.value)"
       =rows  "4"

--- a/pkg/arvo/neo/src/std/con/iframe-htmx.hoon
+++ b/pkg/arvo/neo/src/std/con/iframe-htmx.hoon
@@ -17,6 +17,7 @@
       =style  "border-bottom: 1px solid #777;"
       ;input.p2.grow
         =type  "text"
+        =name  "text"
         =value  url
         =is  "atom-input"
         =oninput  "this.parentNode.nextElementSibling.src = this.value;"

--- a/pkg/arvo/neo/src/std/con/node-diary-diff.hoon
+++ b/pkg/arvo/neo/src/std/con/node-diary-diff.hoon
@@ -1,14 +1,13 @@
 /@  node
 /@  diary-diff
+/-  _/manx-utils
 :-  [%node %diary-diff]
 |=  nod=node
 ^-  diary-diff
-=/  head  (@tas (crip (~(got by (malt a.g.nod)) %head)))
-=/  id-el  (snag 0 c.nod)
-=/  text-el  (snag 1 c.nod)
+=/  head  (@tas (crip (need (~(get-attribute manx-utils nod) %head))))
 =/  id
   %+  slav  %da
-  (crip (~(got by (malt a.g.id-el)) %value))
+  (crip (need (~(value manx-utils nod) "id")))
 =/  text
-  (crip (~(got by (malt a.g.text-el)) %value))
+  (crip (need (~(value manx-utils nod) "text")))
 [%put-entry id text]

--- a/pkg/arvo/neo/src/std/con/node-hoon.hoon
+++ b/pkg/arvo/neo/src/std/con/node-hoon.hoon
@@ -1,8 +1,9 @@
 /@  hoon
 /@  node
+/-  _/manx-utils
 :-  [%node %hoon]
 |=  nod=node
 ^-  hoon
-=/  text  (snag 1 c.nod)
 %-  crip
-(~(got by (malt a.g.text)) %value)
+%-  need
+(~(value manx-utils nod) "text")

--- a/pkg/arvo/neo/src/std/con/node-iframe.hoon
+++ b/pkg/arvo/neo/src/std/con/node-iframe.hoon
@@ -1,7 +1,9 @@
 /@  node
 /@  iframe
+/-  _/manx-utils
 :-  [%node %iframe]
 |=  nod=node
 ^-  iframe
-=/  el  (snag 0 c.nod)
-(crip (~(got by (malt a.g.el)) %value))
+%-  crip
+%-  need
+(~(value manx-utils nod) "text")

--- a/pkg/arvo/neo/src/std/con/node-sail.hoon
+++ b/pkg/arvo/neo/src/std/con/node-sail.hoon
@@ -1,16 +1,15 @@
 /@  node
 /@  sail
+/-  _/manx-utils
 :-  [%node %sail]
 |=  nod=node
 |^
   ^-  sail
-  =/  code-el  (snag 1 c.nod)
   =/  code
-    =/  raw=tape  (~(got by (malt a.g.code-el)) %value)
+    =/  raw=tape  (need (~(value manx-utils nod) "code"))
     ?:  =((rear raw) '\0a')  (crip (snip raw))
     (crip raw)
-  =/  class-el  (snag 0 c.nod)
-  =/  class  (crip (~(got by (malt a.g.class-el)) %value))
+  =/  class  (crip (need (~(value manx-utils nod) "classes")))
   [code class `(render-udon code)]
 ++  render-udon
   |=  code=@t
@@ -27,7 +26,11 @@
     %-  mule
     |.
     !<  manx
-    %+  slap  !>(..zuse)
+    %+  slap
+      ;:  slop
+        !>(manx-utils=manx-utils)
+        !>(..zuse)
+      ==
     (ream udon)
   ?-  -.mul
     %.y  [%.y (manx p.mul)]

--- a/pkg/arvo/neo/src/std/con/node-task-diff.hoon
+++ b/pkg/arvo/neo/src/std/con/node-task-diff.hoon
@@ -1,50 +1,45 @@
 /@  node
 /@  task-diff
+/-  _/manx-utils
 :-  [%node %task-diff]
 |=  nod=node
 ^-  task-diff
-=/  head  (@tas (crip (~(got by (malt a.g.nod)) %head)))
+=/  head  (@tas (crip (need (~(get-attribute manx-utils nod) %head))))
 %-  task-diff
 ?+  head
   ~|  [%unknown-head head]
   !!
     %become
-  =/  path-el  (snag 0 c.nod)
-  ~&  path-el
-  =/  path  (stab (crip (~(got by (malt a.g.path-el)) %value)))
+  =/  path  (stab (crip (need (~(value manx-utils nod) "path"))))
   [head (pave:neo path)]
 ::
     %nest
-  =/  name-el  (snag 0 c.nod)
-  =/  name  (@tas (crip (~(got by (malt a.g.name-el)) %value)))
+  =/  name  (@tas (crip (need (~(value manx-utils nod) "name"))))
   [head name '' | ~]
 ::
     %prep
-  =/  name-el  (snag 0 c.nod)
-  =/  name  (@tas (crip (~(got by (malt a.g.name-el)) %value)))
+  =/  name  (@tas (crip (need (~(value manx-utils nod) "name"))))
   [head name '' | ~]
 ::
     %oust
-  =/  path  (stab (crip (~(got by (malt a.g.nod)) %pith)))
+  =/  path  (stab (crip (need (~(get-attribute manx-utils nod) %pith))))
   [head (pave:neo path)]
 ::
     %edit
-  =/  done-label  (snag 0 c.nod)
-  =/  done-el  (snag 0 c.done-label)
-  =/  text-el  (snag 1 c.nod)
-  =/  text  (crip (~(got by (malt a.g.text-el)) %value))
+  =/  text  (crip (need (~(value manx-utils nod) "text")))
+  =/  done-el  (need (~(named manx-utils nod) "done"))
   =/  done  (~(has by (malt a.g.done-el)) %checked)
   [head text done]
 ::
     %kid-done
-  =/  path  (stab (crip (~(got by (malt a.g.nod)) %pith)))
+  =/  path  (stab (crip (need (~(get-attribute manx-utils nod) %pith))))
   [head (pave:neo path)]
 ::
     %reorder
   =/  piths
     %+  turn  c.nod
     |=  =manx
-    =/  here  (~(get by (malt a.g.manx)) %here)
+    =/  here  (~(get-attribute manx-utils nod) %here)
     ?~  here
       ~&  >>>  [%bad-here manx]
       !!

--- a/pkg/arvo/neo/src/std/con/node-txt.hoon
+++ b/pkg/arvo/neo/src/std/con/node-txt.hoon
@@ -1,7 +1,10 @@
 /@  node
 /@  txt
+/-  _/manx-utils
 :-  [%node %txt]
 |=  nod=node
 ^-  txt
-=/  el  (snag 0 c.nod)
-(crip (~(got by (malt a.g.el)) %value))
+%-  crip
+%-  need
+(~(value manx-utils nod) "text")
+

--- a/pkg/arvo/neo/src/std/con/sail-htmx.hoon
+++ b/pkg/arvo/neo/src/std/con/sail-htmx.hoon
@@ -77,7 +77,7 @@
     =hx-indicator  "#ind-{id}"
     ;input.p2.mono
       =style  "border-bottom: 1px solid var(--f3);"
-      =name  "class"
+      =name  "classes"
       =placeholder  "prose p3"
       =type  "text"
       =autocomplete  "off"

--- a/pkg/arvo/neo/src/std/con/task-htmx.hoon
+++ b/pkg/arvo/neo/src/std/con/task-htmx.hoon
@@ -25,6 +25,7 @@
       ^-  manx
       ;input
         =type  "checkbox"
+        =name  "done"
         =onclick  (trip 'if (this.checked) { this.setAttribute("checked", "")} else {this.removeAttribute("checked")}')
         ;
       ==
@@ -62,7 +63,7 @@
       =hx-swap  "outerHTML"
       =hx-target  "find button .loading"
       ;input.wf.p1.border.br1.grow
-        =name  "text"
+        =name  "name"
         =autocomplete  "off"
         =type  "text"
         =pattern  (trip '[a-z]{1}[a-z0-9\\-]+')
@@ -179,6 +180,7 @@
         =head  "become"
         ;input.grow.p2.br1.border
           =type  "text"
+          =name  "path"
           =value  (en-tape:pith:neo (welp here.bowl pith))
           =oninput  "this.setAttribute('value', this.value);"
           ;

--- a/pkg/arvo/neo/src/std/lib/manx-utils.hoon
+++ b/pkg/arvo/neo/src/std/lib/manx-utils.hoon
@@ -1,0 +1,401 @@
+|_  a=manx
+:: named
+::
+::  first child with name=tape, or null
+::
+++  named
+  |=  name=tape
+  ^-  (unit manx)
+  =/  n
+    %+  skim  pre-flatten
+    |=  =manx
+    =((~(gut by (malt a.g.manx)) %name "") name)
+  ?:  =(0 (lent n))  ~
+  `(snag 0 n)
+:: get-attribute
+::
+::   tape at attribute, or null
+::
+++  get-attribute
+  |=  =mane
+  ^-  (unit tape)
+  (~(get by (malt a.g.a)) mane)
+:: value
+::
+::  value attribute of first named descendant, or null
+++  value
+  |=  name=tape
+  ^-  (unit tape)
+  ?~  t=(named name)  ~
+  =.  a  u.t
+  (get-attribute %value)
+:: whitelisted
+::
+::   check all tags are in whitelist
+::
+++  whitelisted
+  |=  b=(set mane)
+  ^-  ?
+  %-  post-fold
+  |=  [g=marx w=?]
+  ?.  w  w
+  (~(has in b) n.g)
+:: whitelisted
+::
+::   check whether any tags are in blacklist
+::
+++  blacklisted
+  |=  b=(set mane)
+  ^-  ?
+  %-  post-fold
+  |=  [g=marx w=_|]
+  ?:  w  w
+  (~(has in b) n.g)
+:: get-max-depth
+::
+::   deepest node depth (root is 0)
+::
+++  get-max-depth
+  ^-  @ud
+  |-
+  ?~  c.a  0
+  %+  max
+    .+  $(c.a c.i.c.a)
+  $(c.a t.c.a)
+:: apply-elem:
+::
+::   apply gate to tags/attrs
+::
+++  apply-elem
+  |=  b=$-(marx marx)
+  |^  ^-  manx
+  [(b g.a) (cloop c.a)]
+  ++  cloop
+    |=  c=marl
+    ?~  c  ~
+    [^$(a i.c) (cloop t.c)]
+  --
+:: apply-elem-chain
+::
+::   apply gate to tags/attrs with parentage given
+::
+::   gate takes [a b] where a is the current marx
+::   and b is the list of parent marxes in ascending
+::   order (i is the direct parent)
+::
+++  apply-elem-chain
+  =/  ch=(lest marx)  ~[g.a]
+  |=  b=$-([marx (list marx)] marx)
+  |^  ^-  manx
+  [(b ch) (cloop c.a)]
+  ++  cloop
+    |=  c=marl
+    ?~  c  ~
+    [^$(a i.c, ch [g.i.c ch]) (cloop t.c)]
+  --
+:: post-apply-nodes
+::
+::   apply gate to nodes in postorder
+::
+::   (unlike apply-elem, the gate takes the
+::   whole manx instead of just marx)
+::
+++  post-apply-nodes
+  |=  b=$-(manx manx)
+  |^  ^-  manx
+  (b [g.a (cloop c.a)])
+  ++  cloop
+    |=  c=marl
+    ?~  c  ~
+    [^$(a i.c) (cloop t.c)]
+  --
+:: apply-attrs
+::
+::   apply a gate to all attributes
+::
+++  apply-attrs
+  |=  b=$-([mane tape] [mane tape])
+  ^-  manx
+  %-  apply-elem
+  |=  g=marx
+  =|  y=mart
+  |-
+  ?~  a.g  g(a (flop y))
+  $(a.g t.a.g, y [(b i.a.g) y])
+:: apply-text
+::
+::   apply a gate to all ordinary text
+::
+++  apply-text
+  |=  b=$-(tape tape)
+  ^-  manx
+  %-  apply-elem
+  |=  g=marx
+  ?.  ?=(%$ n.g)            g
+  ?~  a.g                   g
+  ?.  ?=(%$ n.i.a.g)        g
+  ?^  t.a.g                 g
+  =.  v.i.a.g  (b v.i.a.g)  g
+:: post-fold
+::
+::   fold over tags/attrs in postorder
+::
+++  post-fold
+  |*  b=_|=([marx *] +<+)
+  ^+  ,.+<+.b
+  |-
+  ?~  c.a  (b g.a +<+.b)
+  $(a a(c t.c.a), +<+.b $(a i.c.a))
+:: pre-fold
+::
+::   fold over tags/attrs in preorder
+::
+++  pre-fold
+  |*  b=_|=([marx *] +<+)
+  ^+  ,.+<+.b
+  |-
+  ?~  c.a
+    ?:  =(%$^%$ n.g.a)
+      +<+.b
+    (b g.a +<+.b)
+  %=    $
+    a  [[%$^%$ ~] t.c.a]
+      +<+.b
+    %=    $
+      a  i.c.a
+        +<+.b
+      ?:  =(%$^%$ n.g.a)
+        +<+.b
+      (b g.a +<+.b)
+    ==
+  ==
+:: lvl-fold
+::
+::   fold over tags/attrs in level order
+::
+++  lvl-fold
+  |*  b=_|=([marx *] +<+)
+  |^  ^+  ,.+<+.b
+  =.  +<+.b  (b g.a +<+.b)
+  (cloop-a c.a +<+.b)
+  ++  cloop-a
+    |=  [c=marl acc=_+<+.b]
+    =/  l  c
+    |-
+    ?~  l  (cloop-b c acc)
+    $(l t.l, acc (b g.i.l acc))
+  ++  cloop-b
+    |=  [c=marl acc=_+<+.b]
+    ?~  c  acc
+    $(c t.c, acc (cloop-a c.i.c acc))
+  --
+:: prune
+::
+::   delete nodes when applied gate produces %.y
+::
+++  prune
+  |=  b=$-(manx ?)
+  |^  ^-  (unit manx)
+  ?:  (b a)  ~
+  [~ g.a (cloop c.a)]
+  ++  cloop
+    =|  fro=marl
+    |=  to=marl
+    ?~  to  (flop fro)
+    =+  u=^$(a i.to)
+    ?~  u  $(to t.to)
+    $(to t.to, fro [u.u fro])
+  --
+:: prune-tag
+::
+::   delete nodes by tag
+::
+++  prune-tag
+  |=  b=mane
+  ^-  (unit manx)
+  (prune |=(x=manx =(b n.g.x)))
+::
+:: prune-tags
+::
+::   delete nodes by tags
+::
+++  prune-tags
+  |=  b=(set mane)
+  ^-  (unit manx)
+  (prune |=(x=manx (~(has in b) n.g.x)))
+:: prune-namespace
+::
+::   delete nodes by tag namespace
+::
+++  prune-namespace
+  |=  b=@tas
+  ^-  (unit manx)
+  (prune |=(x=manx ?@(n.g.x %.n =(b -.n.g.x))))
+:: prune-namespaces
+::
+::   delete nodes by tag namespaces
+::
+++  prune-namespaces
+  |=  b=(set @tas)
+  ^-  (unit manx)
+  (prune |=(x=manx ?@(n.g.x %.n (~(has in b) -.n.g.x))))
+:: prune-attr
+::
+::   delete nodes by attribute name
+::
+++  prune-attr
+  |=  b=mane
+  ^-  (unit manx)
+  %-  prune
+  |=  x=manx
+  %+  roll  a.g.x
+  |=  [[n=mane v=tape] w=_|]
+  ?:(w w =(n b))
+:: prune-attrs
+::
+::   delete nodes by attribute names
+::
+++  prune-attrs
+  |=  b=(set mane)
+  ^-  (unit manx)
+  %-  prune
+  |=  x=manx
+  %+  roll  a.g.x
+  |=  [[n=mane v=tape] w=_|]
+  ?:  w  w
+  (~(has in b) n)
+:: prune-depth
+::
+::   delete nodes deeper than b (root is 0)
+::
+++  prune-depth
+  |=  b=@ud
+  |^  ^-  (unit manx)
+  ?:  =(0 b)  ~
+  [~ g.a (cloop c.a)]
+  ++  cloop
+    |=  to=marl
+    =|  fro=marl
+    |-
+    ?~  to  (flop fro)
+    =/  x   (prune-depth(a i.to) (dec b))
+    ?~  x   $(to t.to)
+    $(to t.to, fro [u.x fro])
+  --
+:: del-attrs
+::
+::   delete attributes by name
+::
+++  del-attrs
+  |=  b=(set mane)
+  ^-  manx
+  %-  apply-elem
+  |=  g=marx
+  =|  y=mart
+  |-
+  ?~  a.g  g(a (flop y))
+  ?:  (~(has in b) n.i.a.g)
+    $(a.g t.a.g)
+  $(a.g t.a.g, y [i.a.g y])
+:: keep-attrs
+::
+::   delete all attributes except those
+::   with the given names
+::
+++  keep-attrs
+  |=  b=(set mane)
+  ^-  manx
+  %-  apply-elem
+  |=  g=marx
+  =|  y=mart
+  |-
+  ?~  a.g  g(a (flop y))
+  ?.  (~(has in b) n.i.a.g)
+    $(a.g t.a.g)
+  $(a.g t.a.g, y [i.a.g y])
+:: post-flatten
+::
+::   get a list of elements by postorder traversal
+::
+++  post-flatten
+  ^-  marl
+  (flop (post-fold |=([g=marx l=marl] [[g ~] l])))
+:: pre-flatten
+::
+::   get a list of elements by preorder traversal
+::
+++  pre-flatten
+  ^-  marl
+  (flop (pre-fold |=([g=marx l=marl] [[g ~] l])))
+:: lvl-flatten
+::
+::   get a list of elements by level order traversal
+::
+++  lvl-flatten
+  ^-  marl
+  (flop (lvl-fold |=([g=marx l=marl] [[g ~] l])))
+:: post-get-text
+::
+::   get a list of plain text by postorder traversal
+::
+++  post-get-text
+  ^-  wall
+  %-  flop
+  %-  post-fold
+  |=  [g=marx l=wall]
+  ?.  ?=(%$ n.g)      l
+  ?~  a.g             l
+  ?.  ?=(%$ n.i.a.g)  l
+  ?^  t.a.g           l
+  :-  v.i.a.g         l
+:: pre-get-text
+::
+::   get a list of plain text by preorder traversal
+::
+++  pre-get-text
+  ^-  wall
+  %-  flop
+  %-  pre-fold
+  |=  [g=marx l=wall]
+  ?.  ?=(%$ n.g)      l
+  ?~  a.g             l
+  ?.  ?=(%$ n.i.a.g)  l
+  ?^  t.a.g           l
+  :-  v.i.a.g         l
+:: lvl-get-text
+::
+::   get a list of plain text by level order traversal
+::
+++  lvl-get-text
+  ^-  wall
+  %-  flop
+  %-  lvl-fold
+  |=  [g=marx l=wall]
+  ?.  ?=(%$ n.g)      l
+  ?~  a.g             l
+  ?.  ?=(%$ n.i.a.g)  l
+  ?^  t.a.g           l
+  :-  v.i.a.g         l
+:: search-text
+::
+:: find plain text containing the given cord
+::
+++  search-text
+  |=  b=@t
+  ^-  wall
+  %-  flop
+  %-  post-fold
+  |=  [g=marx l=wall]
+  ?.  ?=(%$ n.g)      l
+  ?~  a.g             l
+  ?.  ?=(%$ n.i.a.g)  l
+  ?^  t.a.g           l
+  =+  par=(cury (jest b) *hair)
+  ?.  |-
+      ?~  v.i.a.g  %.n
+      ?^  (tail (par v.i.a.g))
+        %.y
+      $(v.i.a.g t.v.i.a.g)
+    l
+  [v.i.a.g l]
+--


### PR DESCRIPTION
adds a forked version of [~tinnus-napbus/manx-utils](https://github.com/tinnus-napbus/manx-utils/blob/master/lib/manx-utils.hoon)

the fork adds these 3 arms:
- `+get-attribute` : get attribute, or null
- `+named`: get first named descendant, or null
- `+value` : get `value` attribute of first named descendant, or null
  - this is the gate you'll use most often

which are useful for writing conversions from `node` to a poke stud.

---

**Example**:


```hoon
::  con/node-txt
/@  node
/@  txt
/-  _/manx-utils
:-  [%node %txt]
|=  nod=node
^-  txt
%-  crip
(need (~(value manx-utils nod) "new-text"))  ::   THIS LINE ...
```

```hoon
::  con/txt-htmx
::  ...
;form
  =hx-post  "/neo/hawk/{...}?stud=txt"
  ;div
    ;div           ::  can be deeply nested
      ;input
        =name  "new-text"            ::  MATCHES ON THIS ATTRIBUTE ...
        =value  "some value"         ::  THEN GETS THIS TAPE
        ;
      ==
    ==
  ==
==
:: ...
```