### PR TITLE
Improvements to the Sail enhancers

### DIFF
--- a/pkg/arvo/app/neo.hoon
+++ b/pkg/arvo/app/neo.hoon
@@ -782,6 +782,15 @@
         return (xmls.serializeToString(elt));
       }
     });
+    Idiomorph.defaults.ignoreActive = true;
+    Idiomorph.defaults.callbacks.beforeAttributeUpdated = (name, node, type) => {
+      if (node.hasAttribute('morph-retain')) {
+        let ribs = node.getAttribute('morph-retain').split(',').map(t => t.trim());
+        if (ribs.includes(name)) {
+          return false;
+        }
+      }
+    }
     '''
     ::
   ++  lift
@@ -794,6 +803,7 @@
         ;title: s k y
         ;script(src "https://code.jquery.com/jquery-3.7.1.js");
         ;script(src "https://unpkg.com/htmx.org@1.9.11");
+        ;script(src "https://unpkg.com/idiomorph/dist/idiomorph-ext.min.js");
         ;script(src "https://unpkg.com/htmx.org@1.9.11/dist/ext/response-targets.js");
         ;script: {html-enc-js}
         ;meta
@@ -848,7 +858,7 @@
         ;+  favicon
       ==
       ;body
-        =hx-ext  "html-enc,response-targets"
+        =hx-ext  "html-enc,response-targets,morph"
         =hx-swap  "innerHTML"
         =hx-boost  "true"
         =hx-history  "false"

--- a/pkg/arvo/neo/src/std/con/node-diary-diff.hoon
+++ b/pkg/arvo/neo/src/std/con/node-diary-diff.hoon
@@ -4,10 +4,8 @@
 :-  [%node %diary-diff]
 |=  nod=node
 ^-  diary-diff
-=/  head  (@tas (crip (need (~(get-attribute manx-utils nod) %head))))
-=/  id
-  %+  slav  %da
-  (crip (need (~(value manx-utils nod) "id")))
-=/  text
-  (crip (need (~(value manx-utils nod) "text")))
+=/  mu  ~(. manx-utils nod)
+=/  head  (@tas (got:mu %head))
+=/  id  (slav %da (vol:mu "id"))
+=/  text  (vol:mu "text")
 [%put-entry id text]

--- a/pkg/arvo/neo/src/std/con/node-hoon.hoon
+++ b/pkg/arvo/neo/src/std/con/node-hoon.hoon
@@ -4,6 +4,4 @@
 :-  [%node %hoon]
 |=  nod=node
 ^-  hoon
-%-  crip
-%-  need
-(~(value manx-utils nod) "text")
+(~(vol manx-utils nod) "text")

--- a/pkg/arvo/neo/src/std/con/node-iframe.hoon
+++ b/pkg/arvo/neo/src/std/con/node-iframe.hoon
@@ -4,6 +4,4 @@
 :-  [%node %iframe]
 |=  nod=node
 ^-  iframe
-%-  crip
-%-  need
-(~(value manx-utils nod) "text")
+(~(vol manx-utils nod) "text")

--- a/pkg/arvo/neo/src/std/con/node-sail.hoon
+++ b/pkg/arvo/neo/src/std/con/node-sail.hoon
@@ -5,11 +5,12 @@
 |=  nod=node
 |^
   ^-  sail
+  =/  mu  ~(. manx-utils nod)
   =/  code
-    =/  raw=tape  (need (~(value manx-utils nod) "code"))
+    =/  raw=tape  (need (val:mu "code"))
     ?:  =((rear raw) '\0a')  (crip (snip raw))
     (crip raw)
-  =/  class  (crip (need (~(value manx-utils nod) "classes")))
+  =/  class  (vol:mu "classes")
   [code class `(render-udon code)]
 ++  render-udon
   |=  code=@t
@@ -28,8 +29,8 @@
     !<  manx
     %+  slap
       ;:  slop
-        !>(manx-utils=manx-utils)
         !>(..zuse)
+        !>(manx-utils=manx-utils)
       ==
     (ream udon)
   ?-  -.mul

--- a/pkg/arvo/neo/src/std/con/node-task-diff.hoon
+++ b/pkg/arvo/neo/src/std/con/node-task-diff.hoon
@@ -4,42 +4,43 @@
 :-  [%node %task-diff]
 |=  nod=node
 ^-  task-diff
-=/  head  (@tas (crip (need (~(get-attribute manx-utils nod) %head))))
+=/  mu  ~(. manx-utils nod)
+=/  head  (@tas (got:mu %head))
 %-  task-diff
 ?+  head
   ~|  [%unknown-head head]
   !!
     %become
-  =/  path  (stab (crip (need (~(value manx-utils nod) "path"))))
+  =/  path  (stab (vol:mu "path"))
   [head (pave:neo path)]
 ::
     %nest
-  =/  name  (@tas (crip (need (~(value manx-utils nod) "name"))))
+  =/  name  (vol:mu "name")
   [head name '' | ~]
 ::
     %prep
-  =/  name  (@tas (crip (need (~(value manx-utils nod) "name"))))
+  =/  name  (vol:mu "name")
   [head name '' | ~]
 ::
     %oust
-  =/  path  (stab (crip (need (~(get-attribute manx-utils nod) %pith))))
+  =/  path  (stab (got:mu %pith))
   [head (pave:neo path)]
 ::
     %edit
-  =/  text  (crip (need (~(value manx-utils nod) "text")))
-  =/  done-el  (need (~(named manx-utils nod) "done"))
+  =/  text  (vol:mu "text")
+  =/  done-el  (need (named:mu "done"))
   =/  done  (~(has by (malt a.g.done-el)) %checked)
   [head text done]
 ::
     %kid-done
-  =/  path  (stab (crip (need (~(get-attribute manx-utils nod) %pith))))
+  =/  path  (stab (got:mu %pith))
   [head (pave:neo path)]
 ::
     %reorder
   =/  piths
     %+  turn  c.nod
     |=  =manx
-    =/  here  (~(get-attribute manx-utils nod) %here)
+    =/  here  (get:mu %here)
     ?~  here
       ~&  >>>  [%bad-here manx]
       !!

--- a/pkg/arvo/neo/src/std/con/node-txt.hoon
+++ b/pkg/arvo/neo/src/std/con/node-txt.hoon
@@ -4,7 +4,5 @@
 :-  [%node %txt]
 |=  nod=node
 ^-  txt
-%-  crip
-%-  need
-(~(value manx-utils nod) "text")
+(~(vol manx-utils nod) "text")
 

--- a/pkg/arvo/neo/src/std/lib/manx-utils.hoon
+++ b/pkg/arvo/neo/src/std/lib/manx-utils.hoon
@@ -12,23 +12,42 @@
     =((~(gut by (malt a.g.manx)) %name "") name)
   ?:  =(0 (lent n))  ~
   `(snag 0 n)
-:: get-attribute
+:: get
 ::
 ::   tape at attribute, or null
 ::
-++  get-attribute
+++  get
   |=  =mane
   ^-  (unit tape)
   (~(get by (malt a.g.a)) mane)
-:: value
+:: got
 ::
-::  value attribute of first named descendant, or null
-++  value
+::   cord of attribute, or crash
+::
+++  got
+  |=  =mane
+  ^-  cord
+  ~|  (crip "cannont find attribute {<mane>}")
+  (crip (need (get mane)))
+:: val
+::
+::   value (tape) attribute of first named descendant, or null
+::
+++  val
   |=  name=tape
   ^-  (unit tape)
   ?~  t=(named name)  ~
   =.  a  u.t
-  (get-attribute %value)
+  (get %value)
+:: vol
+::
+::  value (cord) attribute of first named descendant, or crash
+::
+++  vol
+  |=  name=tape
+  ^-  cord
+  ~|  (crip "cannont find element with name '{<name>}'")
+  (crip (need (val name)))
 :: whitelisted
 ::
 ::   check all tags are in whitelist


### PR DESCRIPTION
# 1. Configured Idiomorph and the `morph-retain` attribute

this swap will retain the specified attributes of the DOM element when swapping it.

a matching strategy provided by the HTMX idiomorph extension does the hard work of matchin DOM elements
and retaining the state (including HTML :focus & :active states)

this allows for subscription-based interfaces that can safely push UI updates which swap overtop a DOM which has local state - without destroying the local state.

example:
```
;div
  =hx-post  "/neo/hawk{...}"
  =hx-swap  "morph"
  =hx-target  "#some-target"
  =morph-retain  "class,open"  ::  these attributes will persist
  ; ...
==
```

# 2. Improved the names of the arms I added to manx-utils

- `got:mu` cord of attribute, or crash
- `get:mu` (unit tape) of attribute, or crash
- `vol:mu` cord of value on named el within `nod`, or crash
- `val:mu` (unit tape) of value on named el within `nod`, or crash