### PR TITLE
sky: add installable app manifest

### DIFF
--- a/pkg/arvo/app/neo.hoon
+++ b/pkg/arvo/app/neo.hoon
@@ -731,38 +731,31 @@
       ==
     ==
     ::
-  ++  svg-wrapper
-    ::
-    |=  [color=tape viewbox=tape body=manx]
-    ^-  manx
-    ;svg
-      =xmlns  "http://www.w3.org/2000/svg"
-      =viewBox  viewbox
-      =fill  color
-      =style  "height: 1em;"
-      ;+  body
-    ==
-    ::
-  ++  svg-square
-    ::
-    |=  color=(unit tape)
-    %^  svg-wrapper  (fall color "currentColor")
-      "0 0 448 512"
-    ;path(d "M0 96C0 60.7 28.7 32 64 32H384c35.3 0 64 28.7 64 64V416c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V96z");
-    ::
+  ++  data-encode
+    |=  [content-type=tape data=tape]
+    (welp "data:{content-type};utf8," data)
+  ++  icon-url
+    %+  welp
+      "https://nyc3.digitaloceanspaces.com"
+    "/drain/hawk/2024.5.17..19.27.01-hawk.png"
   ++  favicon
-    ::
-    =-
-      ;link
-        =rel  "icon"
-        =type  "image/svg+xml"
-        =href  -
-        ;
-      ==
-    %+  weld  "data:image/svg+xml;utf8,"
-    %-  en-xml:html
-    (svg-square `"white")
-    ::
+    ;link
+      =rel  "icon"
+      =type  "img/png"
+      =href  icon-url
+      ;
+    ==
+  ++  manifest-url
+    %+  welp
+      "https://nyc3.digitaloceanspaces.com"
+    "/drain/hawk/2024.5.17..19.48.56-manifest.json"
+  ++  manifest
+    ;link
+      =rel  "manifest"
+      =type  "application/json"
+      =href  manifest-url
+      ;
+    ==
   ++  html-enc-js
     ::
     ::  htmx extension which encodes the request
@@ -856,6 +849,7 @@
         ;script: {(trip s-k-y)}
         ;script: {(trip a-i-r)}
         ;+  favicon
+        ;+  manifest
       ==
       ;body
         =hx-ext  "html-enc,response-targets,morph"
@@ -864,11 +858,22 @@
         =hx-history  "false"
         =hx-replace-url  "/neo/sky"
         =hx-target  "closest ha-wk"
+        =style  "height:100%;"
         ;+  in
       ==
     ==
   --
 ::
+++  html-page-response
+  |=  =manx
+  ^-  simple-payload:http
+  :-  [200 [['content-type' 'text/html'] ~]]
+  :-  ~
+  %-  as-octs:mimes:html
+  %-  crip
+  %+  weld  "<!DOCTYPE html>"
+  %-  en-xml:html
+  manx
 ++  srv
   |_  eyre-id=@ta
   ++  send
@@ -955,7 +960,7 @@
             |-
             ?~  bootstrap
               %-  send
-              %-  manx-response:gen:serv
+              %-  html-page-response
               %-  ~(lift dove pax.purl)
               ;div.wf.hf.fc.jc.ac
                 =hx-get  "/neo/sky"
@@ -971,7 +976,7 @@
             $(bootstrap t.bootstrap)
             ::
         %-  send
-        %-  manx-response:gen:serv
+        %-  html-page-response
         %-  ~(lift dove pax.purl)
         =+  !<(grow=$-(pail:neo $-(=bowl:neo manx)) (all-grow %htmx))
         ?>  ?=(%icon -.seat.u.rum)


### PR DESCRIPTION
this allows you to install this as a PWA on any modern device, including laptops (via Chrome).

the make the manifest installable, it needs to have an image. so the icon image is a hardcoded base64 png that was randomly generated. it is intended as an obviously ugly stub for the eventual real icon.

this also required taking the document out of quirks mode which in turn required that i ditch +manx-response:server for a builder that can add the necessary DOCTYPE directive.