### PR TITLE
get all descendants in kids.bowl in frontends

### DIFF
--- a/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
+++ b/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
@@ -62,8 +62,9 @@
     |=  =pith
     ^-  (unit manx)
     ?~  pith  ~
-    :-  ~
     =/  =path  (pout (welp here.bowl pith))
+    ?:  (gth (lent path) 3)  ~  :: /our/home/whatever
+    :-  ~
     ;div.relative.br2
       =pith  (en-tape:pith:neo pith)
       ;a.b1.br2.block.fc.as.js.hover.p3.s1.border-2.loader

--- a/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
@@ -200,7 +200,7 @@
       ^-  quay:neo
       :-  [[%or rol/[%ui-main pro/%htmx] pro/%htmx ~] ~]
       ^-  (unit port:neo)
-      :+  ~  %y
+      :+  ~  %z
       %-  ~(gas by *lads:neo)
       :~  :-  &
           `lash:neo`[[%or pro/%htmx any/~ ~] ~]


### PR DESCRIPTION
@will-hanlen you cool with this? We need it for Messenger and Tasks.

(The more principled way of fixing home here would be to only grab the top layer of the axal, this is a quick and dirty non-relocatable version.)