### PR TITLE
neo: new overlays

### DIFF
--- a/pkg/arvo/app/neo.hoon
+++ b/pkg/arvo/app/neo.hoon
@@ -38,7 +38,7 @@
       =dive:neo       :: build
     ::
       =gang:neo       :: overlay
-      =lads:neo       :: virtual
+      =pawn:neo       :: virtual
     ::
       =mate:neo       :: peers
     ::
@@ -978,9 +978,25 @@
 ::
 ++  husk
   |_  =stud:neo
+  ++  fren
+    ^-  fren:neo
+    ?:  (~(nest ut -:!>(*kook:neo)) | p:vase)
+      %kook
+    ?:  (~(nest ut -:!>(*chap:neo)) | p:vase)
+      %chap
+    ?:  (~(nest ut -:!>(*bruh:neo)) | p:vase)
+      %bruh
+    !!
+  ::
   ++  dock
     ^-  dock:neo
-    [state poke kids]:kook
+    ~!  kook  ~!  fren 
+    =/  fen  fren
+    ?-  fen
+      %kook  [state poke kids]:kook
+      %chap  *dock:neo
+      %bruh  [state poke ~]:bruh
+    ==
   ::
   ++  pith
     ^-  pith:neo
@@ -1013,7 +1029,8 @@
         `(need pal)
       --
     --
-  ::
+  ++  chap  !<(chap:neo vase)
+  ++  bruh  !<(bruh:neo vase)
   ++  kook
     ^-  kook:neo
     ~|  kook/pith

--- a/pkg/arvo/app/neo.hoon
+++ b/pkg/arvo/app/neo.hoon
@@ -38,7 +38,7 @@
       =dive:neo       :: build
     ::
       =gang:neo       :: overlay
-      =pawn:neo       :: virtual
+      =boys:neo       :: %chap
     ::
       =mate:neo       :: peers
     ::
@@ -434,11 +434,58 @@
   ?:  ?=($@(~ [~ ~]) res)
     res
   ``(~(got of:neo u.u.res) /)
+++  need-look
+  |=  =hunt:neo
+  ^-  [epic:neo _run]
+  [(need (need -)) +]:(look hunt)
 ::
 ++  look
   |=  =hunt:neo
-  ^-  (unit (unit epic:neo))
-  (~(peek till:aux [loam farm]) hunt)
+  ^-  [(unit (unit epic:neo)) _run]
+  =/  res  (~(peek till:aux [loam farm]) hunt)
+  ?.  ?=($?(~ [~ ~]) res)
+    [res run]
+  =/  =name:neo  (de-pith:name:neo pith.hunt)
+  ?.  =(ship.name our.bowl)
+    [~ run]
+  =/  ove=(unit pith:neo)  (~(pfix of:neo gang) pith.name)
+  ?~  ove
+    [`~ run]
+  ~?  !=(%x care.hunt)
+    'warning: non %x cares unsupported rn'
+  =/  inner=pith:neo  (dif:pith:neo pith.name u.ove)
+  =.  run  +:(fight u.ove inner)
+  :_(run (~(peek till:aux [loam farm]) hunt))
+::
+++  fight
+  |=  [over=pith:neo inner=pith:neo]
+  ^-  [(unit pail:neo) _run]
+  =/  =cove:neo  (~(got of:neo gang) over)
+  =/  =bruh:neo  ~(bruh husk code.cove)
+  =/  =crew:neo  (~(put by crew.cove) over.cove inner)
+  =/  pal=(unit pail:neo)  (mole |.(~(make form:bruh (lime deps:bruh crew))))
+  =.  run  +:(take-dirt-card [p/our.bowl (welp over inner)] ?~(pal cull/~ [%grow u.pal ~ *oath:neo]))
+  [pal run]
+::
+++  lime
+  |=  [=band:neo =crew:neo]
+  %-  ~(gas by *(map term [pith lore:neo]))
+  ^-  (list [term pith lore:neo])
+  %+  murn  ~(tap by band)
+  |=  [=term required=? =quay:neo]
+  ^-  (unit [^term pith:neo lore:neo])
+  =/  dep=(unit pith)  (~(get by crew) term)
+  ?~  dep
+    ~|  invariant-missing-required-conf/term
+    ?<  required
+    ~
+  =/  =name:neo  (de-pith:name:neo u.dep)
+  =/  =care:neo  (get-care:quay:neo quay)
+  ?~  lor=(moor quay name)
+    ?<  required
+    ~
+::      %-  (slog term (epic:dbug:neo epic) ~)
+  `[term u.dep u.lor]
 
 ::  +sale: synchronisation
 ++  sale
@@ -736,10 +783,13 @@
   ++  yuga
     |=  =care:neo
     ^-  yuga:neo
-    ?~  pic=(need (look care p/our.bowl pith))
+    =^  pic  run
+      (look care p/our.bowl pith)
+    ?>  ?=(^ pic)
+    ?~  u.pic
       *yuga:neo
     ~&  epic/u.pic
-    (epic-to-yuga u.pic)
+    (epic-to-yuga u.u.pic)
   ::
   ++  stop
     |=  [=care:neo =path]
@@ -801,7 +851,20 @@
     =/  rav  (fall (~(get of:neo riot) pith.hunt) *rave:neo)
     =.  rav  (fume-add rav care.hunt howl)
     =.  riot  (~(put of:neo riot) pith.hunt rav)
-    run
+    (chase hunt howl)
+  ++  chase
+    |=  [=hunt:neo =howl:neo]
+    =/  =name:neo  (de-pith:name:neo pith.hunt)
+    ?.  =(our.bowl ship.name)
+      run
+    ?~  fen=(bond-fren pith.name)
+      run
+    ?.  ?=(%bruh u.fen)
+      run
+    =/  ove=pith:neo  (need (~(pfix of:neo gang) pith.name))
+    =/  =cove:neo  (~(got of:neo gang) ove)
+    ?>  ?=(%x care.hunt)
+    (stalk [care.hunt (dif:pith:neo pith.name ove)] %rely over.cove pith.hunt)
   ++  fury
     |=  gis=(list gift:dirt:neo)
     %-  gas-leaf
@@ -981,6 +1044,8 @@
   ++  fren
     ^-  fren:neo
     ?:  (~(nest ut -:!>(*kook:neo)) | p:vase)
+      %kook
+    ?:  (~(nest ut -:!>(~)) | p:vase)
       %kook
     ?:  (~(nest ut -:!>(*chap:neo)) | p:vase)
       %chap
@@ -1743,6 +1808,7 @@
     ==
   ++  inside  (cury is-parent init)
   ++  echo  arvo  :: TODO walk done
+  ++  fren  (bond-fren here)
   ++  grow
     |=  =pail:neo
     ^+  arvo
@@ -1769,9 +1835,22 @@
     $(arvo new-arvo, done (snoc done nex))
   ++  poke
     |=  =pail:neo
-    ^+  arvo ::    
+    ^+  arvo ::
+    =/  fen  (need fren)
     =^  cards=(list card:neo)  arvo
-      (soft-surf |.(su-abet:(su-poke:surf pail)))
+      ?-    fen
+          %kook
+        (soft-surf |.(su-abet:(su-poke:surf pail)))
+      ::
+          %bruh
+        ?.  =(p.pail %rely)
+          !! :: XX: handle poke unrolling
+        =.  run  +:(look %x [p/our.bowl here])
+        `arvo
+      ::
+          %chap
+        !!
+      ==
     (ingest cards)
   ::
   ::  XX: a hack
@@ -1829,26 +1908,31 @@
   ::
   ++  jazz
     |=  [=conf:neo =deps:neo]
-    ^-  [bad=(set term) block=(set tour:neo)]
-    %+  roll  ~(tap by deps)
-    |=  [[=term required=? =quay:neo] bad=(set term) block=(set hunt:neo)]
+    ^-  [bad=(set term) _run]
+    =/  deps  ~(tap by deps)
+    =|  bad=(set term)
+    |-
+    ?~  deps
+      [bad run]
+    =/  [=term required=? =quay:neo]  i.deps
+    =>  .(deps t.deps)
     =/  =care:neo  (get-care:quay:neo quay)
     ?:  &(required !(~(has by conf) term))
-      :_(block (~(put in bad) term))
+      $(bad (~(put in bad) term))
     ?:  &(!required !(~(has by conf) term))
-      [bad block]
+      $
     =/  pit=pith:neo   (~(got by conf) term)
-    =/  res  (look care pit)
+    =^  res  run  (look care pit)
     =/  nam=name:neo  (de-pith:name:neo pit)
     ?~  res  
       ?:  =(our.bowl ship.nam)
         ?.  required
-          [bad block]
-        :_(block (~(put in bad) term))
-      [bad (~(put in block) care pit)]
-    ?~  u.res
-      :_(block (~(put in bad) term))
-    [bad block] ::
+          $
+        $(bad (~(put in bad) term))
+      $(get.block (~(put in get.block) care pit))
+    ?^  u.res
+      $
+    $(bad (~(put in bad) term))
   ::
   ++  dance
     |=  [=crew:neo =band:neo]
@@ -1884,15 +1968,49 @@
 ::    ~&  >>>  %kids-no-match
 ::    &
     & :: XX: enforce conformance
-  ++  make-plot
-    |=  [src=stud:neo =conf:neo]
+  ::  XX: these are both broken in the event of a %y or %z dependency on
+  ::  the parent
+  ++  make-bruh
+    |=  [src=stud:neo =crew:neo]
+    =/  deps  deps:~(bruh husk src)
+    =^  bad=(set term)   run
+      (jazz crew deps)
+    ?.  =(~ get.block)
+      arvo
+    =/  bad  ~(tap in bad)
+    ?>  =((lent bad) 1)
+    =/  over=term  (snag 0 bad)
+    =.  arvo  (dance crew (~(del by deps) over))
+    =/  =cove:neo  [crew over src *rime:neo]
+    =.  gang  (~(put of:neo gang) here cove)
+    work
+  ++  make-chap
+    |=  [src=stud:neo =crew:neo]
+    =^  bad=(set term)   run
+      (jazz crew deps:~(bruh husk src))
+    ?.  =(~ bad)
+      ~|  bad-chap-crew/bad
+      !!
+    ?.  =(~ get.block)
+      arvo
+    =/  =pawn:neo  [src crew]
+    =.  boys  (~(put of:neo boys) here pawn)
     work
   ::
   ++  make
     |=  [src=stud:neo init=(unit pail:neo) =crew:neo]
+    =/  fen  ~(fren husk src)
+    ?-  fen
+      %kook  (make-kook src init crew)
+      %chap  ?>(=(~ init) (make-chap src crew))
+      %bruh  ?>(=(~ init) (make-bruh src crew))
+    
+    ==
+  ++  make-kook
+    |=  [src=stud:neo init=(unit pail:neo) =crew:neo]
     =/  =wave:neo  [src ~(dock husk src) crew]
     =.  tide  (~(put of:neo tide) here wave)
-    =^  bad=(set term)   get.block
+    =^  bad=(set term)   run
       (jazz crew deps:~(kook husk src))
     ?.  =(~ get.block)
       arvo
@@ -1962,25 +2080,7 @@
       ?~  ion=(scion q.u.kids pith saga)
         ~
       `[pith u.ion]
-    ++  su-deps
-      :: =-  ((slog (deps:dbug:neo -) ~) -)
-      %-  ~(gas by *(map term [pith lore:neo]))
-      ^-  (list [term pith lore:neo])
-      %+  murn  ~(tap by deps:kook)
-      |=  [=term required=? =quay:neo]
-      ^-  (unit [^term pith:neo lore:neo])
-      =/  dep=(unit pith)  (~(get by crew.wave) term)
-      ?~  dep
-        ~|  invariant-missing-required-conf/term
-        ?<  required
-        ~
-      =/  =name:neo  (de-pith:name:neo u.dep)
-      =/  =care:neo  (get-care:quay:neo quay)
-      ?~  lor=(moor quay name)
-        ?<  required
-        ~
-::      %-  (slog term (epic:dbug:neo epic) ~)
-      `[term u.dep u.lor]
+    ++  su-deps  (lime deps:kook crew.wave)
     ::
     ++  su-form  ~(. form:kook [su-bowl su-saga])
     ++  su-abet ::  TODO: bump
@@ -2417,7 +2517,8 @@
   |=  [want=quay:neo =name:neo]
   ^-  (unit lore:neo)
   =/  =care:neo  (get-care:quay:neo want)
-  =/  pic  (~(peek till:aux [loam farm]) care (en-pith:name:neo name))
+  =^  pic=(unit (unit epic:neo))  run
+    (look care (en-pith:name:neo name))
   ?:  ?=($@(~ [~ ~]) pic)
     ~&  lost-moor/name
     ~
@@ -2578,5 +2679,18 @@
   :~  leaf/"Path: {(en-tape:pith:neo pith)}"
       leaf/"{<p.pail>}"
   ==
+++  bond-fren
+  |=  =pith:neo
+  ^-  (unit fren:neo)
+  ?:  (~(has of:neo tide) pith)
+    `%kook
+  ?^  (~(pfix of:neo gang) pith)
+    `%bruh
+  ?^  (~(pfix of:neo boys) pith)
+    `%chap
+  ~
+
+
+
 --
 

--- a/pkg/arvo/neo/cod/std/src/con/counter-htmx.hoon
+++ b/pkg/arvo/neo/cod/std/src/con/counter-htmx.hoon
@@ -1,0 +1,4 @@
+:-  [%atom %$ %htmx]
+|=  a=@
+|=  =bowl:neo
+;div: This is a number {(scow %ud a)}

--- a/pkg/arvo/neo/cod/std/src/con/folder-htmx.hoon
+++ b/pkg/arvo/neo/cod/std/src/con/folder-htmx.hoon
@@ -46,6 +46,7 @@
                 %task
                 %txt
                 %sail
+                %atom
             ==
           |=  t=@tas
           ^-  manx

--- a/pkg/arvo/neo/cod/std/src/imp/accel-conf.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/accel-conf.hoon
@@ -34,8 +34,10 @@
     ++  produce
       |=  =bowl:neo
       ^-  pail:neo
+      =/  pre  (get-prelude bowl)
+      %-  (slog (sell pre) ~)
       =/  res=(each vase tang)
-        (mule |.((slap (get-prelude bowl) (ream hoon.conf))))
+        (mule |.((slap pre (ream hoon.conf))))
       ?:  ?=(%& -.res)
         vase/p.res
       tang/!>(p.res)
@@ -59,8 +61,8 @@
       ^-  (quip card:neo pail:neo)
       =/  new=pail:neo  (produce bowl)
       ?:  =(new pail)
-        `pail
-      :_  pail
+        `new
+      :_  new
       %+  turn  ~(tap by poke.conf)
       |=  [=pith:neo =stud:neo]
       [pith %poke [stud q.pail]]

--- a/pkg/arvo/neo/cod/std/src/imp/accumulator.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/accumulator.hoon
@@ -1,0 +1,33 @@
+=>
+|%
+++  card  card:neo
+--
+^-  kook:neo
+|%
+++  state  pro/%atom
+++  poke  (sy %atom ~)
+++  kids  *kids:neo
+++  deps  *deps:neo
+++  form
+  ^-  form:neo
+  |_  [=bowl:neo =aeon:neo sted=stud:neo sta=vase]
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    ?>  =(%atom stud)
+    =+  !<(atom=@ud vax)
+    :-  ~
+    =-  atom/!>(-)
+    (add atom !<(@ud sta))
+  ::
+  ++  init
+    |=  old=(unit pail:neo)  
+    ^-  (quip card:neo pail:neo)
+    :-  ~
+    =-  atom/!>(-)
+    ?~  old
+      0
+    !<(@ud q.u.old)
+  --
+--
+

--- a/pkg/arvo/neo/cod/std/src/imp/home.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/home.hoon
@@ -19,6 +19,9 @@
         [#/[p/our.bowl]/home/circle %make %circle ~ ~]
         [#/[p/our.bowl]/home/files %make %folder ~ ~]
         [#/[p/our.bowl]/home/planner %make %planner ~ ~]
+        [#/[p/our.bowl]/home/number %make %atom `atom/!>(3) ~]
+        [#/[p/our.bowl]/home/acc %make %accumulator `atom/!>(3) ~]
+        [#/[p/our.bowl]/home/ove %make %inc-ove ~ ~]
     ==
   ++  poke
     |=  =pail:neo

--- a/pkg/arvo/neo/cod/std/src/imp/inc-ove.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/inc-ove.hoon
@@ -1,0 +1,20 @@
+^-  bruh:neo
+|%
+++  state  pro/%atom
+++  poke   ~
+++  deps  
+  %-  ~(gas by *band:neo)
+  :~  in/[& [pro/%atom ~] ~]
+  ==
+::
+++  form
+  |_  deps=(map term (pair pith lore:neo))
+  ++  poke
+    |=  =pail:neo  *(list card:neo)
+  ++  make
+    ^-  pail:neo
+    =+  !<(num=@ud q.pail:(~(got of:neo q:(~(got by deps) %in)) /))
+    atom/!>(+(num))
+  --
+--
+

--- a/pkg/arvo/sur/neo.hoon
+++ b/pkg/arvo/sur/neo.hoon
@@ -2143,11 +2143,69 @@
     *(quip card pail)
   --
 +$  gang  (axal cove)
++$  rime  (map term case)
 +$  cove
   $:  =crew
+      over=term
       code=stud
-      rime=case
+      init=rime
+      :: rime=case
   ==
+::  $bruh: overlay namespace
++$  bruh
+  $_  ^&
+  |%
+  ++  state  *curb
+  ++  poke   *(set stud)
+  ++  deps  *band
+  ++  form
+    $_  ^|
+    |_  deps=(map term lore)
+    ++  poke
+      |~  =pail
+      *(list card)
+    ++  make
+      *pail
+    --
+  --
+++  axle
+  |$  [item]  
+  [fil=(unit item) kid=(map zeta $)]
+
+::  $chap: reshape overlay
+::
+::    example:
+::      /chat/test
+::      /chat/test/received/[id] -> %time (kook)
+::      /chat/test/messages/[id] -> %msg (kook)
+::
+::      /chat/test/sorted/[time] -> (list path)
+::        (axal (list path))
+::
+::      /chat/test/by-ship/[@p] -> (list path)
+::        (axal (list path))
++$  chap
+  $_  ^&
+  |%
+  ++  state  *(axle curb)
+  ++  poke   *(axle (set stud))
+  ++  deps  *band
+  ++  form
+    $_  ^|
+    |_  deps=(map term lore)
+    ++  poke
+      |~  =pail
+      *(list card)
+    ++  make
+      *(axal pail) 
+    --
+  --
++$  pawn
+  $:  code=stud
+      ~
+  ==
++$  fren
+  ?(%chap %bruh %kook)
 ::
 ++  peon
   |%

--- a/pkg/arvo/sur/neo.hoon
+++ b/pkg/arvo/sur/neo.hoon
@@ -1317,6 +1317,7 @@
   $%  [%sell ~]
       [%rely =term =pith]
       [%halt ~]
+      [%over =pith]
   ==
 +$  howl  tone
 ::  $wail: change result
@@ -1625,6 +1626,18 @@
     ?~  +.low
       [pax fil.fat]
     low
+  ::
+  ++  pfix
+    =|  res=(unit pith)
+    =|  here=pith
+    |=  pax=pith
+    ^-  (unit pith)
+    =?  res  ?=(^ fil.fat)
+      `here
+    =/  nex  (dif:pith here pax)
+    ?~  nex
+      res
+    $(fat (~(gut by kid.fat) i.nex [~ ~]), here (snoc here i.nex))
   ::
   ++  has
     |=  pax=pith
@@ -2158,16 +2171,22 @@
   ++  state  *curb
   ++  poke   *(set stud)
   ++  deps  *band
-  ++  form
-    $_  ^|
-    |_  deps=(map term lore)
-    ++  poke
-      |~  =pail
-      *(list card)
-    ++  make
-      *pail
-    --
+  ++  form  *brah
   --
++$  brah
+  $_  ^|
+  |_  deps=(map term (pair pith lore))
+  ++  poke
+    |~  [=stud val=vase]
+    *(list card)
+  ++  make  *pail
+  --
+++  pawn 
+  $:  code=stud
+      =crew
+  ==
+::
+++  boys  (axal pawn)
 ++  axle
   |$  [item]  
   [fil=(unit item) kid=(map zeta $)]
@@ -2200,10 +2219,6 @@
       *(axal pail) 
     --
   --
-+$  pawn
-  $:  code=stud
-      ~
-  ==
 +$  fren
   ?(%chap %bruh %kook)
 ::


### PR DESCRIPTION
cc: @tiller-tolbus @hanfel-dovned @will-hanlen 

$chap is inoperable rn, but not necessary for rn.
$bruh and $brah work by providing all but one of the dependencies into the %make, and the missing dependency will be provided by the overlay.
