### PR TITLE
Remove / from kids.bowl

### DIFF
--- a/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
+++ b/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
@@ -57,6 +57,9 @@
     =/  apps
       %+  welp
         apps.home
+      %-  skip
+      :_  |=  =pith
+          (gth (lent pith) 1)
       %~  tap  in
       %-  %~  dif  in
           %~  key  by
@@ -67,7 +70,6 @@
     |=  =pith
     ^-  (unit manx)
     ?~  pith  ~
-    ?:  (gth (lent pith) 1)  ~
     =/  =path  (pout (welp here.bowl pith))
     :-  ~
     ;div.relative.br2

--- a/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
+++ b/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
@@ -62,8 +62,9 @@
     |=  =pith
     ^-  (unit manx)
     ?~  pith  ~
-    :-  ~
     =/  =path  (pout (welp here.bowl pith))
+    ?:  (gth (lent path) 3)  ~  :: /our/home/whatever
+    :-  ~
     ;div.relative.br2
       =pith  (en-tape:pith:neo pith)
       ;a.b1.br2.block.fc.as.js.hover.p3.s1.border-2.loader

--- a/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
+++ b/pkg/arvo/neo/cod/std/src/con/home-htmx.hoon
@@ -55,15 +55,20 @@
     =hx-indicator  "#indicator-{id}"
     ;*
     =/  apps
-      %+  welp  apps.home
+      %+  welp
+        apps.home
       %~  tap  in
-      (~(dif in ~(key by ~(tar of:neo kids.bowl))) `(set pith)`(silt apps.home))
+      %-  %~  dif  in
+          %~  key  by
+          %~  tar  of:neo 
+          kids.bowl
+      `(set pith)`(silt apps.home)
     %+  murn  apps
     |=  =pith
     ^-  (unit manx)
     ?~  pith  ~
+    ?:  (gth (lent pith) 1)  ~
     =/  =path  (pout (welp here.bowl pith))
-    ?:  (gth (lent path) 3)  ~  :: /our/home/whatever
     :-  ~
     ;div.relative.br2
       =pith  (en-tape:pith:neo pith)

--- a/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
@@ -251,7 +251,7 @@
       =.  our.bol  our.bowl
       =.  now.bol  now.bowl
       =.  eny.bol  eny.bowl
-      =.  kids.bol  q.u.src
+      =.  kids.bol  (~(del of:neo q.u.src) /)
       ::  XX src.bowl
       =/  main  (!<(htmx-type q.pail.root) bol)
       =/  raw

--- a/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
@@ -200,7 +200,7 @@
       ^-  quay:neo
       :-  [[%or rol/[%ui-main pro/%htmx] pro/%htmx ~] ~]
       ^-  (unit port:neo)
-      :+  ~  %y
+      :+  ~  %z
       %-  ~(gas by *lads:neo)
       :~  :-  &
           `lash:neo`[[%or pro/%htmx any/~ ~] ~]


### PR DESCRIPTION
We need all of our descendants in the `kids.bowl` that `hawk-eyre-handler` populates. This is implied by `kids.bowl` being an `(axal idea)` rather than a `(map iota idea)`, and is necessary for both Tasks and Messenger, who need to conditionally render kids on the basis of those kids' kids' state.

The only thing this breaks is how `home` renders its children, which this PR fixes.

I already merged the above changes into `develop` in #41, but they're not in this `wh/revert-role-conversions` branch yet.

This PR is to make those changes, as well as additionally remove `/` from `kids.bowl`. The state of this node probably shouldn't be available in `kids` either way, and in this specific case, it gets passed in as a massive vase containing HTMX (because it was converted through the HTMX role in `hawk-eyre-handler`), which is inaccurate to the user's expectations and locks the ship when `~&`ing `kids.bowl` due to the vase size (and maybe makes Sky slower in general too).

@will-hanlen 