### PR TITLE
blue prototype

### DIFF
--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -28,10 +28,12 @@
     =/  state  !<(blue q.pail)
     ?+    stud  ~|(bad-stud/stud !!)
         %eyre-task
+      ~&  >  'blue got an HTTP request'
       =+  !<(=task:eyre:neo vax)
       =/  [eyre-id=@ta req=inbound-request:eyre]  task
-      =/  inner=pith:neo  
+      =/  inner=pith:neo
         (pave:neo pax:(parse-url:serv request.req))
+      ~&  >  inner   :: /~met/home/diary
       ?.  authenticated.req
         =/  eyre=pith:neo  #/[p/our.bowl]/$/eyre
         :_  pail
@@ -48,11 +50,12 @@
             !>  
             :-  renderers.state
             (~(put by sessions.state) sesh task)
-        :~  :+  (welp here.bowl sesh) 
-              %make
-            :+  %diary-ui  ::  XX (~(got by renderers.state) inner)
-              `[%renderer !>([sesh ~])]
-            (~(gas by *crew:neo) src/inner ~)
+        :~  :*  (welp here.bowl sesh) 
+                %make
+                %diary-ui  ::  XX (~(got by renderers.state) inner)
+                `[%renderer !>([sesh ~])]
+                (~(gas by *crew:neo) src/inner ~)
+            ==
         ==
       ::
           ::  POST: forward poke as manx to session specified by URL
@@ -75,11 +78,12 @@
         ::  gift: A renderer's manx has updated after
         ::        an http request, and now we must respond
         %gift
+      ~&  >  '%gift case of blue'
       :_  pail
       =/  sesh  (gift-session:b !<(gift:neo vax))
       =/  ui  (session-ui:b [bowl sesh])
       =/  [eyre-id=@ta req=inbound-request:eyre]
-        (~(got by sessions.state) sesh)
+        (~(got by sessions.state) sesh)  :: XX sesh needs to be a unit
       ^-  (list card:neo)
       %:  eyre-cards
         eyre-id
@@ -118,7 +122,5 @@
   :~  [pith %poke eyre-sign/!>(head)]
       [pith %poke eyre-sign/!>(data)]
       [pith %poke eyre-sign/!>(done)]
-      [here.bowl %cull ~]  :: XX is this necessary?
-      [here.bowl %tomb ~]
   ==
 --

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -1,0 +1,67 @@
+/@  eyre-reqs
+/@  blue
+/-  serv=sky-server
+/-  srv=server
+::  BLUE FALCON - a prototypical alternative to hawk
+^-  kook:neo
+|%
+++  state  pro/%blue
+++  poke   (sy %eyre-task ~)
+++  kids
+  :+  ~  %y
+  ^-  (map pish:neo lash:neo)
+  %-  malt
+  :~  :-  [|/%uv |]
+      [pro/%eyre-task ~]
+  ==
+++  deps
+  %-  ~(gas by *band:neo)
+  ~
+::
+++  form
+  |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    ?+    stud  ~|(bad-stud/stud !!)
+        %eyre-task
+      =+  !<(=task:eyre:neo vax)
+      =/  [eyre-id=@ta req=inbound-request:eyre]  task
+      ?.  authenticated.req
+        =/  eyre=pith:neo  #/[p/our.bowl]/$/eyre
+        :_  pail
+        %+  ~(respond neo:srv eyre)   eyre-id
+        (login-redirect:gen:srv request.req)
+      =/  purl  (parse-url:serv request.req)
+      =/  inner=pith:neo  (pave:neo pax.purl)
+      ~&  >  inner
+      =/  =crew:neo  (~(gas by *crew:neo) src/inner ~)
+      =/  state  !<(blue q.pail)
+      ::=/  rend=(unit stud:neo)
+      ::  (~(get by renderers.state) inner)
+      =/  rend  [~ %diary-ui]
+      ~&  >  rend
+      ::  XX handle case where there's no UI saved in shadow
+      ::  XX allow user to specify a UI via url params
+      ::  XX handle wizard and tree cases via URL params
+      ::  XX handle case where nothing exists at this pith
+      ::     in here rather than in the renderer
+      ?~  rend  !!
+      =/  =made:neo  [(need rend) `[stud vax] crew]
+      ~&  >  made
+      :_  pail
+      :~  [(welp here.bowl #/[uv/(end 3^4 eny.bowl)]) %make made]
+      ==
+    ==
+  ++  init
+    |=  pal=(unit pail:neo)
+    =/  renderers  
+      (malt (limo [[#/[p/our.bowl]/home/diary %diary-ui] ~]))
+    :_  [%blue !>(renderers)]
+    =/  =pith:neo  #/[p/our.bowl]/$/eyre
+    =/  =binding:eyre  [~ ~[%neo %blue]]
+    =/  =req:eyre:neo  [%connect binding here.bowl]
+    :~  [pith %poke eyre-req/!>(req)]
+    ==
+  --
+--

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -4,9 +4,7 @@
 /-  serv=sky-server
 /-  srv=server
 /-  b=blue
-::  BLUE FALCON - a prototypical alternative to hawk
 ^-  kook:neo
-=<
 |%
 ++  state  pro/%blue
 ++  poke   (sy %eyre-task %gift ~)
@@ -14,7 +12,7 @@
   :+  ~  %y
   %-  malt
   :~  :-  [|/%uv |]
-      [pro/%renderer (sy %manx ~)]
+      [pro/%renderer (sy %http-request ~)]
   ==
 ++  deps
   %-  ~(gas by *band:neo)
@@ -28,12 +26,10 @@
     =/  state  !<(blue q.pail)
     ?+    stud  ~|(bad-stud/stud !!)
         %eyre-task
-      ~&  >  'blue got an HTTP request'
       =+  !<(=task:eyre:neo vax)
       =/  [eyre-id=@ta req=inbound-request:eyre]  task
       =/  inner=pith:neo
         (pave:neo pax:(parse-url:serv request.req))
-      ~&  >  inner   :: /~met/home/diary
       ?.  authenticated.req
         =/  eyre=pith:neo  #/[p/our.bowl]/$/eyre
         :_  pail
@@ -46,10 +42,10 @@
           ::       and wait for its manx as a %gift
           %'GET'
         =/  sesh=road:neo  #/[uv/(end 3^4 eny.bowl)]
-        :_  :-  %blue
-            !>  
-            :-  renderers.state
-            (~(put by sessions.state) sesh task)
+        :_  :-  %blue 
+            !>
+            :-  renderers.state 
+            (~(put by sessions.state) [sesh eyre-id])
         :~  :*  (welp here.bowl sesh) 
                 %make
                 %diary-ui  ::  XX (~(got by renderers.state) inner)
@@ -58,69 +54,61 @@
             ==
         ==
       ::
-          ::  POST: forward poke as manx to session specified by URL
-          ::        and update the top-level session's task
-          ::        so we know who to respond to when %gift comes in
+          ::  POST: forward post to session specified by URL
           %'POST'
-        =/  sesh  
-          ^-  road:neo
-          [(snag 0 inner) ~]
-        =/  body  (parse-body:serv request.req)
-        :_  :-  %blue
-            !>  
-            :-  renderers.state
-            (~(put by sessions.state) sesh task)
+        :_  pail
         :~  :-  (welp here.bowl inner) 
-            [%poke [%manx !>(body)]]
+            [%poke [%http-request !>(request.req)]]
         ==
       ==
     ::
-        ::  gift: A renderer's manx has updated after
-        ::        an http request, and now we must respond
+        ::  gift: A renderer's state has updated.
+        ::        Forward to corresponding eyre-id.
         %gift
-      ~&  >  '%gift case of blue'
-      :_  pail
-      =/  sesh  (gift-session:b !<(gift:neo vax))
+      =/  gift  !<(gift:neo vax)
+      =/  sesh  (gift-session:b gift)
+      =/  =mode:neo  mode:(~(got of:neo gift) sesh)
+      =/  eyre-id  (~(got by sessions.state) sesh)
+      ::
       =/  ui  (session-ui:b [bowl sesh])
-      =/  [eyre-id=@ta req=inbound-request:eyre]
-        (~(got by sessions.state) sesh)  :: XX sesh needs to be a unit
+      =/  data=sign:eyre:neo  
+        :*  eyre-id 
+            %data
+            `(as-octt:mimes:html (en-xml:html ui))
+        ==
+      ::
+      =/  head=sign:eyre:neo  
+        :*  eyre-id 
+            %head 
+            200
+            :~  ['Content-Type' 'text/event-stream']
+                ['Cache-Control' 'no-cache']
+                ['Connection' 'keep-alive']
+            ==
+        ==
+      ::
+      :_  pail
       ^-  (list card:neo)
-      %:  eyre-cards
-        eyre-id
-        bowl
-        200
-        ['content-type' 'text/html']~
-        ui
+      =+  #/[p/our.bowl]/$/eyre
+      ?-    mode
+          %del  
+        ~|('%blue got a %del gift' !!)
+          %dif  
+        :~  [- %poke eyre-sign/!>(data)]
+        ==
+          %add
+        :~  [- %poke eyre-sign/!>(head)]
+            [- %poke eyre-sign/!>(data)]
+        ==
       ==
     ==
   ++  init
     |=  pal=(unit pail:neo)
-    ::=/  renderers  
-    ::  (malt (limo [[#/[p/our.bowl]/home/diary %diary-ui] ~]))
-    =/  renderers  ~
-    :_  [%blue !>([renderers ~])]
+    :_  [%blue !>([~ ~])]
     =/  =pith:neo  #/[p/our.bowl]/$/eyre
     =/  =binding:eyre  [~ ~[%neo %blue]]
     =/  =req:eyre:neo  [%connect binding here.bowl]
     :~  [pith %poke eyre-req/!>(req)]
     ==
   --
---
-::
-|%
-++  manx-to-octs
-  |=  man=manx
-  (as-octt:mimes:html (en-xml:html man))
-::
-++  eyre-cards
-  |=  [eyre-id=@ta =bowl:neo status=@ud =header-list:http =manx]
-  ^-  (list card:neo)
-  =/  =pith:neo  #/[p/our.bowl]/$/eyre
-  =/  head=sign:eyre:neo  [eyre-id %head [status header-list]]
-  =/  data=sign:eyre:neo  [eyre-id %data `(manx-to-octs manx)]
-  =/  done=sign:eyre:neo  [eyre-id %done ~]
-  :~  [pith %poke eyre-sign/!>(head)]
-      [pith %poke eyre-sign/!>(data)]
-      [pith %poke eyre-sign/!>(done)]
-  ==
 --

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -1,18 +1,19 @@
 /@  eyre-reqs
 /@  blue
+/@  renderer
 /-  serv=sky-server
 /-  srv=server
 ::  BLUE FALCON - a prototypical alternative to hawk
 ^-  kook:neo
+=<
 |%
 ++  state  pro/%blue
-++  poke   (sy %eyre-task ~)
+++  poke   (sy %eyre-task %gift ~)
 ++  kids
   :+  ~  %y
-  ^-  (map pish:neo lash:neo)
   %-  malt
   :~  :-  [|/%uv |]
-      [pro/%eyre-task ~]
+      [pro/%renderer (sy %manx ~)]
   ==
 ++  deps
   %-  ~(gas by *band:neo)
@@ -23,40 +24,88 @@
   ++  poke
     |=  [=stud:neo vax=vase]
     ^-  (quip card:neo pail:neo)
+    =/  state  !<(blue q.pail)
     ?+    stud  ~|(bad-stud/stud !!)
+        ::  gift: A renderer's manx has updated after
+        ::        an http request, and now we're responding
+        %gift
+      ::  Find which top-level session this gift
+      ::  (or series of gifts) came from
+      :_  pail
+      =/  sesh=road:neo
+        =-  ?~  -  !!  :: if no top-level gifts, ignore
+            -<-
+        %+  skim
+          ~(tap of:neo !<(gift:neo vax))
+        |=  [=road:neo =loot:neo]
+        =(1 (lent road))
+      ::  Grab the corresponding eyre-task from sessions
+      ::  and respond with updated UI
+      =/  [eyre-id=@ta req=inbound-request:eyre]
+        (~(got by sessions.state) sesh)
+      =/  ui
+        =/  =idea:neo  (~(got of:neo kids.bowl) sesh)
+        =/  =pail:neo  q.saga.idea
+        (need ui:!<(renderer q.pail))
+      ^-  (list card:neo)
+      %:  eyre-cards
+        eyre-id
+        bowl
+        200
+        ['content-type' 'text/html']~
+        ui
+      ==
+    ::
         %eyre-task
       =+  !<(=task:eyre:neo vax)
       =/  [eyre-id=@ta req=inbound-request:eyre]  task
+      =/  inner=pith:neo  
+        (pave:neo pax:(parse-url:serv request.req))
       ?.  authenticated.req
         =/  eyre=pith:neo  #/[p/our.bowl]/$/eyre
         :_  pail
         %+  ~(respond neo:srv eyre)   eyre-id
         (login-redirect:gen:srv request.req)
-      =/  purl  (parse-url:serv request.req)
-      =/  inner=pith:neo  (pave:neo pax.purl)
-      ~&  >  inner
-      =/  =crew:neo  (~(gas by *crew:neo) src/inner ~)
-      =/  state  !<(blue q.pail)
-      ::=/  rend=(unit stud:neo)
-      ::  (~(get by renderers.state) inner)
-      =/  rend  [~ %diary-ui]
-      ~&  >  rend
-      ::  XX handle case where there's no UI saved in shadow
-      ::  XX allow user to specify a UI via url params
-      ::  XX handle wizard and tree cases via URL params
-      ::  XX handle case where nothing exists at this pith
-      ::     in here rather than in the renderer
-      ?~  rend  !!
-      =/  =made:neo  [(need rend) `[stud vax] crew]
-      ~&  >  made
-      :_  pail
-      :~  [(welp here.bowl #/[uv/(end 3^4 eny.bowl)]) %make made]
+      ::
+      ?+    method.request.req  
+          ~|(%unsupported-http-method !!)
+          ::  GET: make a renderer at a new session
+          ::       and wait for its manx as a %gift
+          %'GET'
+        =/  sesh=road:neo  #/[uv/(end 3^4 eny.bowl)]
+        :_  :-  %blue
+            !>  
+            :-  renderers.state
+            (~(put by sessions.state) sesh task)
+        :~  :+  (welp here.bowl sesh) 
+              %make
+            :+  %diary-ui  ::  (~(got by renderers.state) inner)
+              `[%renderer !>([sesh ~])]
+            (~(gas by *crew:neo) src/inner ~)
+        ==
+      ::
+          ::  POST: forward poke as manx to session specified by URL
+          ::        and update the top-level session's task
+          ::        so we know who to respond to when %gift comes in
+          %'POST'
+        =/  sesh  
+          ^-  road:neo
+          [(snag 0 inner) ~]
+        =/  body  (parse-body:serv request.req)
+        :_  :-  %blue
+            !>  
+            :-  renderers.state
+            (~(put by sessions.state) sesh task)
+        :~  :-  (welp here.bowl inner) 
+            [%poke [%manx !>(body)]]
+        ==
       ==
     ==
   ++  init
     |=  pal=(unit pail:neo)
-    =/  renderers  
-      (malt (limo [[#/[p/our.bowl]/home/diary %diary-ui] ~]))
+    ::=/  renderers  
+    ::  (malt (limo [[#/[p/our.bowl]/home/diary %diary-ui] ~]))
+    =/  renderers  ~
     :_  [%blue !>(renderers)]
     =/  =pith:neo  #/[p/our.bowl]/$/eyre
     =/  =binding:eyre  [~ ~[%neo %blue]]
@@ -64,4 +113,24 @@
     :~  [pith %poke eyre-req/!>(req)]
     ==
   --
+--
+::
+|%
+++  manx-to-octs
+  |=  man=manx
+  (as-octt:mimes:html (en-xml:html man))
+::
+++  eyre-cards
+  |=  [eyre-id=@ta =bowl:neo status=@ud =header-list:http =manx]
+  ^-  (list card:neo)
+  =/  =pith:neo  #/[p/our.bowl]/$/eyre
+  =/  head=sign:eyre:neo  [eyre-id %head [status header-list]]
+  =/  data=sign:eyre:neo  [eyre-id %data `(manx-to-octs manx)]
+  =/  done=sign:eyre:neo  [eyre-id %done ~]
+  :~  [pith %poke eyre-sign/!>(head)]
+      [pith %poke eyre-sign/!>(data)]
+      [pith %poke eyre-sign/!>(done)]
+      [here.bowl %cull ~]  :: XX is this necessary?
+      [here.bowl %tomb ~]
+  ==
 --

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -26,36 +26,6 @@
     ^-  (quip card:neo pail:neo)
     =/  state  !<(blue q.pail)
     ?+    stud  ~|(bad-stud/stud !!)
-        ::  gift: A renderer's manx has updated after
-        ::        an http request, and now we're responding
-        %gift
-      ::  Find which top-level session this gift
-      ::  (or series of gifts) came from
-      :_  pail
-      =/  sesh=road:neo
-        =-  ?~  -  !!  :: if no top-level gifts, ignore
-            -<-
-        %+  skim
-          ~(tap of:neo !<(gift:neo vax))
-        |=  [=road:neo =loot:neo]
-        =(1 (lent road))
-      ::  Grab the corresponding eyre-task from sessions
-      ::  and respond with updated UI
-      =/  [eyre-id=@ta req=inbound-request:eyre]
-        (~(got by sessions.state) sesh)
-      =/  ui
-        =/  =idea:neo  (~(got of:neo kids.bowl) sesh)
-        =/  =pail:neo  q.saga.idea
-        (need ui:!<(renderer q.pail))
-      ^-  (list card:neo)
-      %:  eyre-cards
-        eyre-id
-        bowl
-        200
-        ['content-type' 'text/html']~
-        ui
-      ==
-    ::
         %eyre-task
       =+  !<(=task:eyre:neo vax)
       =/  [eyre-id=@ta req=inbound-request:eyre]  task
@@ -79,7 +49,7 @@
             (~(put by sessions.state) sesh task)
         :~  :+  (welp here.bowl sesh) 
               %make
-            :+  %diary-ui  ::  (~(got by renderers.state) inner)
+            :+  %diary-ui  ::  XX (~(got by renderers.state) inner)
               `[%renderer !>([sesh ~])]
             (~(gas by *crew:neo) src/inner ~)
         ==
@@ -100,13 +70,43 @@
             [%poke [%manx !>(body)]]
         ==
       ==
+    ::
+        ::  gift: A renderer's manx has updated after
+        ::        an http request, and now we must respond
+        %gift
+      ::  Find which top-level session this gift
+      ::  (or series of gifts) came from
+      :_  pail
+      =/  sesh=road:neo
+        =-  ?~  -  !!  :: if no top-level gifts, ignore request
+            -<-
+        %+  skim
+          ~(tap of:neo !<(gift:neo vax))
+        |=  [=road:neo =loot:neo]
+        =(1 (lent road))
+      ::  Grab the corresponding eyre-task from sessions
+      ::  and respond with updated UI
+      =/  [eyre-id=@ta req=inbound-request:eyre]
+        (~(got by sessions.state) sesh)
+      =/  ui
+        =/  =idea:neo  (~(got of:neo kids.bowl) sesh)
+        =/  =pail:neo  q.saga.idea
+        (need ui:!<(renderer q.pail))
+      ^-  (list card:neo)
+      %:  eyre-cards
+        eyre-id
+        bowl
+        200
+        ['content-type' 'text/html']~
+        ui
+      ==
     ==
   ++  init
     |=  pal=(unit pail:neo)
     ::=/  renderers  
     ::  (malt (limo [[#/[p/our.bowl]/home/diary %diary-ui] ~]))
     =/  renderers  ~
-    :_  [%blue !>(renderers)]
+    :_  [%blue !>([renderers ~])]
     =/  =pith:neo  #/[p/our.bowl]/$/eyre
     =/  =binding:eyre  [~ ~[%neo %blue]]
     =/  =req:eyre:neo  [%connect binding here.bowl]

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -3,6 +3,7 @@
 /@  renderer
 /-  serv=sky-server
 /-  srv=server
+/-  b=blue
 ::  BLUE FALCON - a prototypical alternative to hawk
 ^-  kook:neo
 =<
@@ -74,24 +75,11 @@
         ::  gift: A renderer's manx has updated after
         ::        an http request, and now we must respond
         %gift
-      ::  Find which top-level session this gift
-      ::  (or series of gifts) came from
       :_  pail
-      =/  sesh=road:neo
-        =-  ?~  -  !!  :: if no top-level gifts, ignore request
-            -<-
-        %+  skim
-          ~(tap of:neo !<(gift:neo vax))
-        |=  [=road:neo =loot:neo]
-        =(1 (lent road))
-      ::  Grab the corresponding eyre-task from sessions
-      ::  and respond with updated UI
+      =/  sesh  (gift-session:b !<(gift:neo vax))
+      =/  ui  (session-ui:b [bowl sesh])
       =/  [eyre-id=@ta req=inbound-request:eyre]
         (~(got by sessions.state) sesh)
-      =/  ui
-        =/  =idea:neo  (~(got of:neo kids.bowl) sesh)
-        =/  =pail:neo  q.saga.idea
-        (need ui:!<(renderer q.pail))
       ^-  (list card:neo)
       %:  eyre-cards
         eyre-id

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -63,28 +63,20 @@
       ==
     ::
         ::  gift: A renderer's state has updated.
-        ::        Forward to corresponding eyre-id.
+        ::        If top-level, forward to corresponding eyre-id.
         %gift
       =/  gift  !<(gift:neo vax)
       =/  sesh  (gift-session:b gift)
-      =/  =mode:neo  mode:(~(got of:neo gift) sesh)
-      =/  eyre-id  (~(got by sessions.state) sesh)
+      ?~  sesh
+        [~ pail]
+      =/  =mode:neo  mode:(~(got of:neo gift) u.sesh)
+      =/  eyre-id  (~(got by sessions.state) u.sesh)
       ::
-      =/  ui  (session-ui:b [bowl sesh])
+      =/  ui  (session-ui:b [bowl u.sesh])
       =/  data=sign:eyre:neo  
         :*  eyre-id 
             %data
             `(as-octt:mimes:html (en-xml:html ui))
-        ==
-      ::
-      =/  head=sign:eyre:neo  
-        :*  eyre-id 
-            %head 
-            200
-            :~  ['Content-Type' 'text/event-stream']
-                ['Cache-Control' 'no-cache']
-                ['Connection' 'keep-alive']
-            ==
         ==
       ::
       :_  pail
@@ -97,7 +89,19 @@
         :~  [- %poke eyre-sign/!>(data)]
         ==
           %add
-        :~  [- %poke eyre-sign/!>(head)]
+        :~  :*  - 
+                %poke 
+                :-  %eyre-sign
+                !>
+                :*  eyre-id 
+                    %head 
+                    200
+                    :~  ['Content-Type' 'text/event-stream']
+                        ['Cache-Control' 'no-cache']
+                        ['Connection' 'keep-alive']
+                    ==
+                ==
+            ==
             [- %poke eyre-sign/!>(data)]
         ==
       ==

--- a/pkg/arvo/neo/cod/std/src/imp/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/blue.hoon
@@ -20,6 +20,9 @@
 ::
 ++  form
   |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  init
+    |=  pal=(unit pail:neo)
+    [~ [%blue !>([~ ~])]]
   ++  poke
     |=  [=stud:neo vax=vase]
     ^-  (quip card:neo pail:neo)
@@ -42,10 +45,7 @@
           ::       and wait for its manx as a %gift
           %'GET'
         =/  sesh=road:neo  #/[uv/(end 3^4 eny.bowl)]
-        :_  :-  %blue 
-            !>
-            :-  renderers.state 
-            (~(put by sessions.state) [sesh eyre-id])
+        :_  blue/!>([renderers.state `eyre-id])
         :~  :*  (welp here.bowl sesh) 
                 %make
                 %diary-ui  ::  XX (~(got by renderers.state) inner)
@@ -63,56 +63,41 @@
       ==
     ::
         ::  gift: A renderer's state has updated.
-        ::        If top-level, forward to corresponding eyre-id.
+        ::        If top-level and in response to a request, 
+        ::        forward to corresponding eyre-id.
         %gift
+      ?~  open-eyre-id.state  [~ pail]
+      =/  id  u.open-eyre-id.state
       =/  gift  !<(gift:neo vax)
-      =/  sesh  (gift-session:b gift)
-      ?~  sesh
-        [~ pail]
-      =/  =mode:neo  mode:(~(got of:neo gift) u.sesh)
-      =/  eyre-id  (~(got by sessions.state) u.sesh)
-      ::
-      =/  ui  (session-ui:b [bowl u.sesh])
-      =/  data=sign:eyre:neo  
-        :*  eyre-id 
-            %data
-            `(as-octt:mimes:html (en-xml:html ui))
-        ==
-      ::
-      :_  pail
+      =/  sesh  (get-session:b gift)
+      ?~  sesh  [~ pail]
+      :_  blue/!>([renderers.state ~])
       ^-  (list card:neo)
       =+  #/[p/our.bowl]/$/eyre
-      ?-    mode
-          %del  
-        ~|('%blue got a %del gift' !!)
-          %dif  
-        :~  [- %poke eyre-sign/!>(data)]
-        ==
-          %add
-        :~  :*  - 
-                %poke 
-                :-  %eyre-sign
-                !>
-                :*  eyre-id 
-                    %head 
-                    200
-                    :~  ['Content-Type' 'text/event-stream']
-                        ['Cache-Control' 'no-cache']
-                        ['Connection' 'keep-alive']
-                    ==
-                ==
-            ==
-            [- %poke eyre-sign/!>(data)]
-        ==
+      :~  :*  - 
+              %poke 
+              %eyre-sign
+              !>
+              :^    id 
+                  %head 
+                200
+              ['content-type' 'text/html']~
+          ==
+      ::
+          :*  - 
+              %poke 
+              %eyre-sign
+              !>
+              :+  id 
+                %data
+              :-  ~
+              %-  as-octt:mimes:html
+              %-  en-xml:html
+              (get-ui:b [bowl u.sesh])
+          ==
+      ::
+          [- %poke eyre-sign/!>([id %done ~])]
       ==
-    ==
-  ++  init
-    |=  pal=(unit pail:neo)
-    :_  [%blue !>([~ ~])]
-    =/  =pith:neo  #/[p/our.bowl]/$/eyre
-    =/  =binding:eyre  [~ ~[%neo %blue]]
-    =/  =req:eyre:neo  [%connect binding here.bowl]
-    :~  [pith %poke eyre-req/!>(req)]
     ==
   --
 --

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -1,8 +1,12 @@
 /@  renderer
+/@  diary-diff
+/-  feather-icons
+/-  manx-utils
 ^-  kook:neo
+=<
 |%
 ++  state  pro/%renderer
-++  poke   (sy %manx ~)
+++  poke   (sy %manx %rely %gift ~)
 ++  kids
   :+  ~  %y
   %-  malt
@@ -12,15 +16,12 @@
 ++  deps
   %-  ~(gas by *band:neo)
   :~  :-  %src
-      ^-  fief:neo
       :-  req=&
-      ^-  quay:neo
       :-  [pro/%diary (sy %diary-diff ~)]
-      ^-  (unit port:neo)
       :+  ~  %y
       %-  ~(gas by *lads:neo)
-      :~  :-  [[%.n %da] %.n]
-          `lash:neo`[[%only %txt] ~]
+      :~  :-  [|/%da |]
+          [[%only %txt] ~]
       ==
   ==
 ::
@@ -29,19 +30,133 @@
   ++  poke
     |=  [=stud:neo vax=vase]
     ^-  (quip card:neo pail:neo)
-    !!
+    ?+    stud  !!
+    ::  rely: The shrub we're rendering updated its state.
+    ::        Re-render the UI and save it to our state.
+        %rely
+      =/  sesh  session:!<(renderer q.pail)
+      [~ renderer/!>([sesh ~(render html [bowl sesh])])]
+    ::
+    ::  manx: A poke comes in as a manx. Parse it,
+    ::        forward it, and then wait for the %rely.
+        %manx
+      =;  poke
+        :_  pail
+        :~  :+  p:(~(got by deps.bowl) %src) 
+              %poke
+            [%diary-diff !>(poke)]
+        ==
+      ^-  diary-diff
+      =/  post  !<(manx vax)
+      =/  mu  ~(. manx-utils post)
+      =/  head  (@tas (got:mu %head))
+      ?+    head  !!
+          %put-entry
+        =/  id  (slav %da (vol:mu "now"))
+        =/  text  (vol:mu "text")
+        [%put-entry id text]
+      ::
+          %del-entry
+        [%del-entry (slav %da (got:mu %diary-id))]
+      ==
+    ==
+  ::
   ++  init
     |=  pal=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
     =/  [=stud:neo =vase]  (need pal)
     =/  sesh  session:!<(renderer vase)
-    :-  ~
-    :-  %renderer
-    !>
-    :-  sesh
+    [~ renderer/!>([sesh ~(render html [bowl sesh])])]
+  --
+--
+::
+|%
+++  html
+  |_  [=bowl:neo sesh=road:neo]
+  ++  render
     ^-  manx
-    ;div.fc.jc.ac.wf.hf
-      ; hello world
+    ;div.p-page
+      ;div.ma.fc.g2.mw-page
+        ;+  form-put-entry
+        ;*
+        %-  turn
+        :_  link-entry
+        %+  sort
+          %~  tap
+            of:neo
+          %.  /
+          %~  del 
+            of:neo
+          q:(~(got by deps.bowl) %src)
+        |=  [a=[=pith *] b=[=pith *]]
+        (gth ->.pith.a ->.pith.b)
+      == 
     ==
+  ::
+  ++  form-put-entry
+    ;form.fc.g2
+      =style         "margin-bottom: 30px;"
+      =hx-post       "/neo/blue{(en-tape:pith:neo sesh)}"
+      =hx-on-submit  "this.reset()"
+      =hx-target     "find .loading"
+      =hx-swap       "outerHTML"
+      =head          "put-entry"
+      ;date-now(name "now");
+      ;textarea.p2.bd1.br1
+        =name  "text"
+        =placeholder  "today, i ..."
+        =oninput  "this.setAttribute('value', this.value)"
+        =rows  "5"
+        =required  ""
+        =autocomplete  "off"
+        ;
+      ==
+      ;button.p2.b1.br1.bd1.wfc.hover.loader
+        ;span.loaded.s2: create
+        ;span.loading
+          ;+  loading.feather-icons
+        ==
+      ==
+    ==
+  ::
+  ++  link-entry
+    |=  [pax=pith =idea:neo]
+    =/  tape  (trip !<(@t q.q.saga.idea))
+    =/  subject-end  (fall (find [10]~ tape) 56)
+    =/  subject  (scag subject-end tape)
+    =/  id  (trip (snag 0 (pout pax)))
+    ;div.fr.g2
+      ;a.p2.br1.grow.b1.hover.loader
+        ::  XX can't open this on its own until blue
+        ::     can use other top-level renderers
+        ::  =href  "{(en-tape:pith:neo (weld /neo/blue sesh))}/{id}"
+        ;div.loaded.fc.g1.js.as.g2
+          ;span.f3: {(pretty-date `@da`->:pax)}
+          ;span.bold: {subject}
+        ==
+        ;span.loading
+          ;+  loading.feather-icons
+        ==
+      ==
+      ;button.p2.br1.fr.g2.b1.hover.fc.ac.jc.loader
+        =hx-post  "/neo/blue{(en-tape:pith:neo sesh)}"
+        =head  "del-entry"
+        =hx-target  "find .loading"
+        =hx-swap  "outerHTML"
+        =diary-id  id
+        ;span.loaded
+          ;+  close.feather-icons
+        ==
+        ;span.loading
+          ;+  loading.feather-icons
+        ==
+      ==
+    ==
+  ::
+  ++  pretty-date
+    |=  date=@da
+    ^-  tape
+    =/  d  (yore date)
+    "{(y-co:co y:d)}-{(y-co:co m:d)}-{(y-co:co d:t:d)}"
   --
 --

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -64,6 +64,7 @@
   ++  init
     |=  pal=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
+    ~&  >  'on-init of diary-ui'
     =/  [=stud:neo =vase]  (need pal)
     (render [bowl vase])
   --

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -34,7 +34,8 @@
     ^-  (quip card:neo pail:neo)
     ?+    stud  !!
         %rely
-      (render [bowl q.pail])
+      =/  dep  p:(~(got by deps.bowl) %src) 
+      (reset:b [bowl %diary-ui pail dep])
     ::
         %gift
       (render-child:b [!<(gift:neo vax) bowl q.pail])

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -1,0 +1,126 @@
+/@  htmx-type=htmx
+/-  serv=sky-server
+/-  render
+/>  htmx
+/<  node
+/<  http-request
+^-  kook:neo
+|%
+++  state  pro/%eyre-task
+++  poke   *(set stud:neo)
+++  kids  *kids:neo
+++  deps
+  %-  ~(gas by *band:neo)
+  :~  :-  %src
+      ^-  fief:neo
+      :-  req=&
+      ^-  quay:neo
+      :-  [pro/%diary (sy %diary-diff ~)]
+      ^-  (unit port:neo)
+      :+  ~  %y
+      %-  ~(gas by *lads:neo)
+      :~  :-  [[%.n %da] %.n]
+          `lash:neo`[[%only %txt] ~]
+      ==
+  ==
+::
+++  form
+  |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    !!
+  ++  init
+    |=  pal=(unit pail:neo)
+    ^-  (quip card:neo pail:neo)
+    ~&  >  "*** diary-ui on-init ***"
+    =/  [=stud:neo =vase]  (need pal)
+    :_  [stud vase]
+    =+  !<([eyre-id=@ta req=inbound-request:eyre] vase)
+    =/  purl  (parse-url:serv request.req)
+    =/  id=@da  (slav %da (~(gut by pam.purl) 'hawk-id' '~2000.1.1'))
+    =/  slot=@ud  (slav %ud (~(gut by pam.purl) 'slot' '999'))
+    =/  meta  [id slot]
+    =/  src  (~(got by deps.bowl) %src)
+    =/  here  p.src
+    ^-  (list card:neo)
+    ?+    method.request.req  ~|(%unsupported-http-method !!)
+        %'GET'
+      =/  root=idea:neo  (~(got of:neo q.src) /)
+      =;  ui
+        %:  eyre-cards:render
+          eyre-id
+          bowl
+          200
+          ['content-type' 'text/html']~
+          ui
+        ==
+      ^-  manx
+      ;div.fc.jc.ac.wf.hf
+        ; hello world
+      ==
+::        %'POST'
+::      =/  purl  (parse-url:serv request.req)
+::      =/  content-type  (~(gut by pam.purl) 'content-type' 'text/html')
+::      =/  body  (parse-body:serv request.req)
+::      =/  poke-stud
+::        ^-  stud:neo
+::        ~|  %no-stud-specified
+::        (~(got by pam.purl) 'stud')
+::      =/  mul
+::        %-  mule
+::        |.
+::        ?:  =(content-type 'application/x-www-form-urlencoded')
+::          (http-request [poke-stud `request:http`request.req])
+::        (node [poke-stud body])
+::      ?-    -.mul
+::          %.n
+::        %:  eyre-cards
+::            eyre-id
+::            bowl
+::            500
+::            :~
+::              ['content-type' 'text/html']
+::              ['HX-Reswap' 'outerHTML']
+::            ==
+::            ;div.b0.p-page.wf.hf.fc.g2.as
+::              ;a.p2.br1.bd1.b1.hover.loader.block
+::                =href  "/neo/hawk{(spud pax.purl)}"
+::                ;span.loaded: reload
+::                ;span.loading
+::                  ;+  loading.feather-icons
+::                ==
+::              ==
+::              ;+  (print-tang (tang p.mul))
+::            ==
+::        ==
+::      ::
+::          %.y
+::        =/  =pail:neo  [poke-stud p.mul]
+::        =/  bol  *bowl:neo
+::        =.  here.bol  here
+::        =.  our.bol  our.bowl
+::        =.  now.bol  now.bowl
+::        =.  eny.bol  eny.bowl
+::        =/  =manx
+::          ?~  converter=(mole |.((htmx pail)))
+::            (default-refresher here)
+::          =/  mul
+::            %-  mule
+::            |.((u.converter bol))
+::          ?-  -.mul
+::            %.y  p.mul
+::            %.n  ;div: error
+::          ==
+::        :-  [here %poke pail]
+::        %:  eyre-cards
+::            eyre-id
+::            bowl
+::            200
+::            ['content-type' 'text/html']~
+::            manx
+::        ==
+::      ==
+    ==
+  --
+--

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -1,5 +1,6 @@
 /@  renderer
 /@  diary-diff
+/-  serv=sky-server
 /-  feather-icons
 /-  manx-utils
 /-  b=blue
@@ -7,12 +8,12 @@
 =<
 |%
 ++  state  pro/%renderer
-++  poke   (sy %manx %rely %gift ~)
+++  poke   (sy %http-request %rely %gift ~)
 ++  kids
   :+  ~  %y
   %-  malt
   :~  :-  [|/%uv |]
-      [pro/%renderer (sy %manx ~)]
+      [pro/%renderer (sy %http-request ~)]
   ==
 ++  deps
   %-  ~(gas by *band:neo)
@@ -38,8 +39,9 @@
         %gift
       (render-child:b [!<(gift:neo vax) bowl q.pail])
     ::
-    ::  A poke comes in as a manx. Forward it and wait for %rely.
-        %manx
+    ::  A poke comes in as a POST request. 
+    ::  Forward it and wait for %rely.
+        %http-request
       =;  poke
         :_  pail
         :~  :+  p:(~(got by deps.bowl) %src) 
@@ -47,8 +49,8 @@
             [%diary-diff !>(poke)]
         ==
       ^-  diary-diff
-      =/  post  !<(manx vax)
-      =/  mu  ~(. manx-utils post)
+      =/  body  (parse-body:serv !<(request:http vax))
+      =/  mu  ~(. manx-utils body)
       =/  head  (@tas (got:mu %head))
       ?+    head  !!
           %put-entry
@@ -64,7 +66,6 @@
   ++  init
     |=  pal=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
-    ~&  >  'on-init of diary-ui'
     =/  [=stud:neo =vase]  (need pal)
     (render [bowl vase])
   --

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -2,6 +2,7 @@
 /@  diary-diff
 /-  feather-icons
 /-  manx-utils
+/-  b=blue
 ^-  kook:neo
 =<
 |%
@@ -31,14 +32,13 @@
     |=  [=stud:neo vax=vase]
     ^-  (quip card:neo pail:neo)
     ?+    stud  !!
-    ::  rely: The shrub we're rendering updated its state.
-    ::        Re-render the UI and save it to our state.
         %rely
-      =/  sesh  session:!<(renderer q.pail)
-      [~ renderer/!>([sesh ~(render html [bowl sesh])])]
+      (render [bowl q.pail])
     ::
-    ::  manx: A poke comes in as a manx. Parse it,
-    ::        forward it, and then wait for the %rely.
+        %gift
+      (render-child:b [!<(gift:neo vax) bowl q.pail])
+    ::
+    ::  A poke comes in as a manx. Forward it and wait for %rely.
         %manx
       =;  poke
         :_  pail
@@ -65,33 +65,43 @@
     |=  pal=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
     =/  [=stud:neo =vase]  (need pal)
-    =/  sesh  session:!<(renderer vase)
-    [~ renderer/!>([sesh ~(render html [bowl sesh])])]
+    (render [bowl vase])
   --
 --
 ::
 |%
+++  render
+  |=  [=bowl:neo =vase]
+  ^-  (quip card:neo pail:neo)
+  =/  sesh  session:!<(renderer vase)
+  =/  mac=[manx (list card:neo)]
+    ~(render html [bowl sesh])
+  :-  +.mac
+  renderer/!>([sesh `-.mac])
+::
 ++  html
   |_  [=bowl:neo sesh=road:neo]
   ++  render
-    ^-  manx
-    ;div.p-page
-      ;div.ma.fc.g2.mw-page
-        ;+  form-put-entry
-        ;*
-        %-  turn
-        :_  link-entry
-        %+  sort
-          %~  tap
-            of:neo
-          %.  /
-          %~  del 
-            of:neo
-          q:(~(got by deps.bowl) %src)
-        |=  [a=[=pith *] b=[=pith *]]
-        (gth ->.pith.a ->.pith.b)
-      == 
-    ==
+    ^-  [manx (list card:neo)]
+    =;  entries=(list [manx card:neo])
+      :_  (turn entries |=([* =card:neo] card))
+      ;div.p-page
+        ;div.ma.fc.g2.mw-page
+          ;+  form-put-entry
+          ;*  (turn entries |=([=manx *] manx))
+        == 
+      ==
+    %-  turn
+    :_  (recur:b [%txt-ui bowl sesh])
+    %+  sort
+      %~  tap
+        of:neo
+      %.  /
+      %~  del 
+        of:neo
+      q:(~(got by deps.bowl) %src)
+    |=  [a=[=pith *] b=[=pith *]]
+    (gth ->.pith.a ->.pith.b)
   ::
   ++  form-put-entry
     ;form.fc.g2
@@ -118,45 +128,5 @@
         ==
       ==
     ==
-  ::
-  ++  link-entry
-    |=  [pax=pith =idea:neo]
-    =/  tape  (trip !<(@t q.q.saga.idea))
-    =/  subject-end  (fall (find [10]~ tape) 56)
-    =/  subject  (scag subject-end tape)
-    =/  id  (trip (snag 0 (pout pax)))
-    ;div.fr.g2
-      ;a.p2.br1.grow.b1.hover.loader
-        ::  XX can't open this on its own until blue
-        ::     can use other top-level renderers
-        ::  =href  "{(en-tape:pith:neo (weld /neo/blue sesh))}/{id}"
-        ;div.loaded.fc.g1.js.as.g2
-          ;span.f3: {(pretty-date `@da`->:pax)}
-          ;span.bold: {subject}
-        ==
-        ;span.loading
-          ;+  loading.feather-icons
-        ==
-      ==
-      ;button.p2.br1.fr.g2.b1.hover.fc.ac.jc.loader
-        =hx-post  "/neo/blue{(en-tape:pith:neo sesh)}"
-        =head  "del-entry"
-        =hx-target  "find .loading"
-        =hx-swap  "outerHTML"
-        =diary-id  id
-        ;span.loaded
-          ;+  close.feather-icons
-        ==
-        ;span.loading
-          ;+  loading.feather-icons
-        ==
-      ==
-    ==
-  ::
-  ++  pretty-date
-    |=  date=@da
-    ^-  tape
-    =/  d  (yore date)
-    "{(y-co:co y:d)}-{(y-co:co m:d)}-{(y-co:co d:t:d)}"
   --
 --

--- a/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary-ui.hoon
@@ -1,14 +1,14 @@
-/@  htmx-type=htmx
-/-  serv=sky-server
-/-  render
-/>  htmx
-/<  node
-/<  http-request
+/@  renderer
 ^-  kook:neo
 |%
-++  state  pro/%eyre-task
-++  poke   *(set stud:neo)
-++  kids  *kids:neo
+++  state  pro/%renderer
+++  poke   (sy %manx ~)
+++  kids
+  :+  ~  %y
+  %-  malt
+  :~  :-  [|/%uv |]
+      [pro/%renderer (sy %manx ~)]
+  ==
 ++  deps
   %-  ~(gas by *band:neo)
   :~  :-  %src
@@ -33,94 +33,15 @@
   ++  init
     |=  pal=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
-    ~&  >  "*** diary-ui on-init ***"
     =/  [=stud:neo =vase]  (need pal)
-    :_  [stud vase]
-    =+  !<([eyre-id=@ta req=inbound-request:eyre] vase)
-    =/  purl  (parse-url:serv request.req)
-    =/  id=@da  (slav %da (~(gut by pam.purl) 'hawk-id' '~2000.1.1'))
-    =/  slot=@ud  (slav %ud (~(gut by pam.purl) 'slot' '999'))
-    =/  meta  [id slot]
-    =/  src  (~(got by deps.bowl) %src)
-    =/  here  p.src
-    ^-  (list card:neo)
-    ?+    method.request.req  ~|(%unsupported-http-method !!)
-        %'GET'
-      =/  root=idea:neo  (~(got of:neo q.src) /)
-      =;  ui
-        %:  eyre-cards:render
-          eyre-id
-          bowl
-          200
-          ['content-type' 'text/html']~
-          ui
-        ==
-      ^-  manx
-      ;div.fc.jc.ac.wf.hf
-        ; hello world
-      ==
-::        %'POST'
-::      =/  purl  (parse-url:serv request.req)
-::      =/  content-type  (~(gut by pam.purl) 'content-type' 'text/html')
-::      =/  body  (parse-body:serv request.req)
-::      =/  poke-stud
-::        ^-  stud:neo
-::        ~|  %no-stud-specified
-::        (~(got by pam.purl) 'stud')
-::      =/  mul
-::        %-  mule
-::        |.
-::        ?:  =(content-type 'application/x-www-form-urlencoded')
-::          (http-request [poke-stud `request:http`request.req])
-::        (node [poke-stud body])
-::      ?-    -.mul
-::          %.n
-::        %:  eyre-cards
-::            eyre-id
-::            bowl
-::            500
-::            :~
-::              ['content-type' 'text/html']
-::              ['HX-Reswap' 'outerHTML']
-::            ==
-::            ;div.b0.p-page.wf.hf.fc.g2.as
-::              ;a.p2.br1.bd1.b1.hover.loader.block
-::                =href  "/neo/hawk{(spud pax.purl)}"
-::                ;span.loaded: reload
-::                ;span.loading
-::                  ;+  loading.feather-icons
-::                ==
-::              ==
-::              ;+  (print-tang (tang p.mul))
-::            ==
-::        ==
-::      ::
-::          %.y
-::        =/  =pail:neo  [poke-stud p.mul]
-::        =/  bol  *bowl:neo
-::        =.  here.bol  here
-::        =.  our.bol  our.bowl
-::        =.  now.bol  now.bowl
-::        =.  eny.bol  eny.bowl
-::        =/  =manx
-::          ?~  converter=(mole |.((htmx pail)))
-::            (default-refresher here)
-::          =/  mul
-::            %-  mule
-::            |.((u.converter bol))
-::          ?-  -.mul
-::            %.y  p.mul
-::            %.n  ;div: error
-::          ==
-::        :-  [here %poke pail]
-::        %:  eyre-cards
-::            eyre-id
-::            bowl
-::            200
-::            ['content-type' 'text/html']~
-::            manx
-::        ==
-::      ==
+    =/  sesh  session:!<(renderer vase)
+    :-  ~
+    :-  %renderer
+    !>
+    :-  sesh
+    ^-  manx
+    ;div.fc.jc.ac.wf.hf
+      ; hello world
     ==
   --
 --

--- a/pkg/arvo/neo/cod/std/src/imp/entry-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/entry-ui.hoon
@@ -23,6 +23,7 @@
   ++  init
     |=  pal=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
+    ~&  >  "entry-ui init"
     =/  [=stud:neo =vase]  (need pal)
     =/  sesh  session:!<(renderer vase)
     :-  ~

--- a/pkg/arvo/neo/cod/std/src/imp/entry-ui.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/entry-ui.hoon
@@ -1,0 +1,65 @@
+/@  renderer
+/-  feather-icons
+^-  kook:neo
+=<
+|%
+++  state  pro/%renderer
+++  poke   ~
+++  kids  *kids:neo
+++  deps
+  %-  ~(gas by *band:neo)
+  :~  :-  %src
+      :-  req=&
+      :-  [pro/%txt ~]
+      ~
+  ==
+::
+++  form
+  |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    !!
+  ::
+  ++  init
+    |=  pal=(unit pail:neo)
+    ^-  (quip card:neo pail:neo)
+    =/  [=stud:neo =vase]  (need pal)
+    =/  sesh  session:!<(renderer vase)
+    :-  ~
+    :-  %renderer
+    !>
+    :-  sesh
+    :-  ~
+    ^-  manx
+    =/  pax
+      p:(~(got by deps.bowl) %src)
+    =/  =idea:neo
+      %.  / 
+      %~  got
+        of:neo
+      q:(~(got by deps.bowl) %src)
+    =/  text  !<(@t q.pail.idea)
+    =/  tape  (trip text)
+    =/  subject-end  (fall (find [10]~ tape) 56)
+    =/  subject  (scag subject-end tape)
+    ;div.fr.g2
+      ;a.p2.br1.grow.b1.hover.loader
+        ;div.loaded.fc.g1.js.as.g2
+          ;span.f3: {(pretty-date `@da`->:pax)}
+          ;span.bold: {subject}
+        ==
+        ;span.loading
+          ;+  loading.feather-icons
+        ==
+      ==
+    ==
+  --
+--
+::
+|%
+++  pretty-date
+  |=  date=@da
+  ^-  tape
+  =/  d  (yore date)
+  "{(y-co:co y:d)}-{(y-co:co m:d)}-{(y-co:co d:t:d)}"
+--

--- a/pkg/arvo/neo/cod/std/src/imp/prism.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/prism.hoon
@@ -1,0 +1,51 @@
+/@  eyre-reqs
+/@  blue
+/@  renderer
+/-  serv=sky-server
+/-  srv=server
+^-  kook:neo
+|%
+++  state  pro/%sig
+++  poke   (sy %eyre-task ~)
+++  kids
+  :+  ~  %y
+  %-  malt
+  :~  :-  [|/%uv |]
+      [pro/%sig (sy %http-request ~)]
+  ==
+++  deps
+  %-  ~(gas by *band:neo)
+  ~
+::
+++  form
+  |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    ?>  =(%eyre-task stud)  
+    =+  !<(=task:eyre:neo vax)
+    =/  [eyre-id=@ta req=inbound-request:eyre]  task
+    =/  inner=pith:neo
+      (pave:neo pax:(parse-url:serv request.req))
+    ?.  authenticated.req
+      =/  eyre=pith:neo  #/[p/our.bowl]/$/eyre
+      :_  pail
+      %+  ~(respond neo:srv eyre)   eyre-id
+      (login-redirect:gen:srv request.req)
+    =/  color  #/blue  :: XX derive this from URL param
+    :_  pail
+    :~  :-  (welp here.bowl color) 
+        [%poke [stud vax]]
+    ==
+  ::
+  ++  init
+    |=  pal=(unit pail:neo)
+    :_  sig/!>(~)
+    =/  =pith:neo  #/[p/our.bowl]/$/eyre
+    =/  =binding:eyre  [~ ~[%neo %prism]]
+    =/  =req:eyre:neo  [%connect binding here.bowl]
+    :~  [pith %poke eyre-req/!>(req)]
+        [(welp here.bowl #/blue) %make %blue ~ ~]
+    ==
+  --
+--

--- a/pkg/arvo/neo/cod/std/src/lib/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/blue.hoon
@@ -20,16 +20,18 @@
     `[%renderer !>([id ~])]
   (~(gas by *crew:neo) src/pax ~)
 ::
-::  A child renderer has updated its state.
-::  Plug its new manx into the matching div.
+::  If gift is from an immediate child, swap.
 ++  render-child
   |=  [=gift:neo =bowl:neo =vase]
   ^-  (quip card:neo pail:neo)
-  =/  ui  (need ui:!<(renderer vase))
+  =/  state  !<(renderer vase)
+  =/  ui  (need ui.state)
   =/  sesh  (gift-session gift)
-  =/  sub  (session-ui [bowl sesh])
-  =/  new  (swap [ui sub sesh])
-  [~ renderer/!>([sesh new])]
+  ?~  sesh
+    [~ renderer/vase]
+  =/  sub  (session-ui [bowl u.sesh])
+  =/  new  (swap [ui sub u.sesh])
+  [~ renderer/!>([session.state new])]
 ::
 ::  Find the div in main with this id,
 ::  and replace it with sub.
@@ -48,12 +50,6 @@
     sub
   (wit:hu [c t])
 ::
-++  gift-ui
-  |=  [=gift:neo =bowl:neo]
-  ^-  manx
-  =/  sesh  (gift-session gift)
-  (session-ui [bowl sesh])
-::
 ::  Get the current UI from the renderer matching this session
 ++  session-ui
   |=  [=bowl:neo sesh=road:neo]
@@ -62,15 +58,14 @@
   =/  =pail:neo  q.saga.idea
   (need ui:!<(renderer q.pail))
 ::
-::  Find which top-level session this gift
-::  (or series of gifts) came from
+::  Find which immediate child this gift came from.
+::  If not from an immediate child, return null.
 ++  gift-session
   |=  =gift:neo
-  ^-  road:neo
+  ^-  (unit road:neo)
   =-  ?~  -  
-        ~|('gift-session crash' !!)
-        :: if no top-level gifts, ignore request
-      -<-
+        ~
+      `-<-
   %+  skim
     ~(tap of:neo gift)
   |=  [=road:neo =loot:neo]

--- a/pkg/arvo/neo/cod/std/src/lib/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/blue.hoon
@@ -2,6 +2,21 @@
 /-  manx-utils
 /-  html-utils
 |%
+++  reset
+  |=  [=bowl:neo =stud:neo =pail:neo dep=pith:neo]
+  =/  p
+    %+  welp  
+      ~[[%p our.bowl] %blue]
+    session:!<(renderer q.pail)
+  :_  pail
+  :~  [p %tomb ~]
+      :*  p
+          %make
+          stud
+          `[%renderer pail]
+          (~(gas by *crew:neo) src/dep ~)
+      ==
+  ==
 ::
 ::  Create a placeholder div and renderer for this child.
 ++  recur

--- a/pkg/arvo/neo/cod/std/src/lib/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/blue.hoon
@@ -1,0 +1,64 @@
+/@  renderer
+|%
+::
+::  Create a placeholder div and renderer for this child.
+++  recur
+  |=  [renderer=stud:neo =bowl:neo sesh=road:neo]
+  |=  [pax=pith *]
+  ^-  [manx card:neo]
+  =/  id  #/[uv/(end 3^4 eny.bowl)]
+  :-  
+  ;div.fr.g2
+    =id  (trip (snag 0 (pout id)))
+    Child
+  ==
+  :+  :(welp #/neo/blue sesh id)
+    %make
+  :+  %renderer 
+    `[%renderer !>([id ~])]
+  (~(gas by *crew:neo) src/pax ~)
+::
+::  A child renderer has updated its state.
+::  Plug its new manx into the matching div.
+++  render-child
+  |=  [=gift:neo =bowl:neo =vase]
+  ^-  (quip card:neo pail:neo)
+  =/  ui  (need ui:!<(renderer vase))
+  =/  sesh  (gift-session gift)
+  =/  sub  (session-ui [bowl sesh])
+  =/  new  (swap [ui sub sesh])
+  [~ renderer/!>([sesh new])]
+::
+::  Find the div in main with this id,
+::  and replace it with sub.
+++  swap
+  |=  [main=manx sub=manx id=road:neo]
+  ^-  manx
+  main
+::
+++  gift-ui
+  |=  [=gift:neo =bowl:neo]
+  ^-  manx
+  =/  sesh  (gift-session gift)
+  (session-ui [bowl sesh])
+::
+::  Get the current UI from the renderer matching this session
+++  session-ui
+  |=  [=bowl:neo sesh=road:neo]
+  ^-  manx
+  =/  =idea:neo  (~(got of:neo kids.bowl) sesh)
+  =/  =pail:neo  q.saga.idea
+  (need ui:!<(renderer q.pail))
+::
+::  Find which top-level session this gift
+::  (or series of gifts) came from
+++  gift-session
+  |=  =gift:neo
+  ^-  road:neo
+  =-  ?~  -  !!  :: if no top-level gifts, ignore request
+      -<-
+  %+  skim
+    ~(tap of:neo gift)
+  |=  [=road:neo =loot:neo]
+  =(1 (lent road))
+--

--- a/pkg/arvo/neo/cod/std/src/lib/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/blue.hoon
@@ -1,4 +1,6 @@
 /@  renderer
+/-  manx-utils
+/-  html-utils
 |%
 ::
 ::  Create a placeholder div and renderer for this child.
@@ -9,12 +11,12 @@
   =/  id  #/[uv/(end 3^4 eny.bowl)]
   :-  
   ;div.fr.g2
-    =id  (trip (snag 0 (pout id)))
+    =name  (trip (snag 0 (pout id)))
     Child
   ==
   :+  :(welp #/neo/blue sesh id)
     %make
-  :+  %renderer 
+  :+  renderer 
     `[%renderer !>([id ~])]
   (~(gas by *crew:neo) src/pax ~)
 ::
@@ -34,7 +36,17 @@
 ++  swap
   |=  [main=manx sub=manx id=road:neo]
   ^-  manx
-  main
+  =/  name  (trip (snag 0 (pout id)))
+  =/  hu  ~(. mx:html-utils main)
+  =/  c=con:hu
+    |=  [=path =manx]
+    ^-  ?
+    =/  mu  ~(. manx-utils manx)
+    =(name (got:mu %name))
+  =/  t=tan:hu
+    |=  [=path =manx]
+    sub
+  (wit:hu [c t])
 ::
 ++  gift-ui
   |=  [=gift:neo =bowl:neo]

--- a/pkg/arvo/neo/cod/std/src/lib/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/blue.hoon
@@ -13,7 +13,7 @@
       :*  p
           %make
           stud
-          `[%renderer pail]
+          `pail
           (~(gas by *crew:neo) src/dep ~)
       ==
   ==
@@ -41,10 +41,10 @@
   ^-  (quip card:neo pail:neo)
   =/  state  !<(renderer vase)
   =/  ui  (need ui.state)
-  =/  sesh  (gift-session gift)
+  =/  sesh  (get-session gift)
   ?~  sesh
     [~ renderer/vase]
-  =/  sub  (session-ui [bowl u.sesh])
+  =/  sub  (get-ui [bowl u.sesh])
   =/  new  (swap [ui sub u.sesh])
   [~ renderer/!>([session.state new])]
 ::
@@ -66,7 +66,7 @@
   (wit:hu [c t])
 ::
 ::  Get the current UI from the renderer matching this session
-++  session-ui
+++  get-ui
   |=  [=bowl:neo sesh=road:neo]
   ^-  manx
   =/  =idea:neo  (~(got of:neo kids.bowl) sesh)
@@ -75,7 +75,7 @@
 ::
 ::  Find which immediate child this gift came from.
 ::  If not from an immediate child, return null.
-++  gift-session
+++  get-session
   |=  =gift:neo
   ^-  (unit road:neo)
   =-  ?~  -  

--- a/pkg/arvo/neo/cod/std/src/lib/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/blue.hoon
@@ -67,7 +67,9 @@
 ++  gift-session
   |=  =gift:neo
   ^-  road:neo
-  =-  ?~  -  !!  :: if no top-level gifts, ignore request
+  =-  ?~  -  
+        ~|('gift-session crash' !!)
+        :: if no top-level gifts, ignore request
       -<-
   %+  skim
     ~(tap of:neo gift)

--- a/pkg/arvo/neo/cod/std/src/lib/render.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/render.hoon
@@ -1,0 +1,297 @@
+/-  feather-icons
+|%
+++  manx-to-octs
+  |=  man=manx
+  (as-octt:mimes:html (en-xml:html man))
+::
+++  eyre-cards
+  |=  [eyre-id=@ta =bowl:neo status=@ud =header-list:http =manx]
+  ^-  (list card:neo)
+  =/  =pith:neo  #/[p/our.bowl]/$/eyre
+  =/  head=sign:eyre:neo  [eyre-id %head [status header-list]]
+  =/  data=sign:eyre:neo  [eyre-id %data `(manx-to-octs manx)]
+  =/  done=sign:eyre:neo  [eyre-id %done ~]
+  :~  [pith %poke eyre-sign/!>(head)]
+      [pith %poke eyre-sign/!>(data)]
+      [pith %poke eyre-sign/!>(done)]
+      [here.bowl %cull ~]  :: XX is this necessary?
+      [here.bowl %tomb ~]
+  ==
+++  print-tang
+  |=  =tang
+  ;div.prose
+    ;h1: crash!
+    ;pre
+      ;code
+        ;*
+        %+  turn  tang
+        |=  =tank
+        ;/((of-wall:format (~(win re tank) 0 55)))
+      ==
+    ==
+  ==
+++  sky-move-tab
+  |=  [=bowl:neo slot=@ud]
+  ::  assumes location of sky is /sky
+  [#/[p/our.bowl]/sky %poke %sky-diff !>([%move-tab slot here.bowl])]
+++  default-refresher
+  |=  =pith
+  =/  tath  (en-tape:pith:neo pith)
+  ;div.loading
+    =hx-get  "/neo/hawk{tath}"
+    =hx-target  "closest .rendered"
+    =hx-select  ".rendered"
+    =hx-trigger  "load once"
+    =hx-indicator  "closest .loader"
+    =hx-swap  "outerHTML"
+    ;+  loading.feather-icons
+  ==
+++  raw-view
+  |=  =bowl:neo
+  ;div.fc.g1.p-page
+    ;details.bd1.br1.b0
+      ;summary.p2.bold: state
+      ;+
+      ?~  node=(~(get of:neo kids.bowl) /)
+        ;div.p2: none
+      =/  =pail:neo  q.saga.u.node
+      ;div.fc.g2.as.p2
+        ;a.p1.mono.f2.b1.br1.bd1.hover.loader
+          =href  "/neo/hawk/{(scow %p our.bowl)}/cod/std/src/pro/{(trip ?@(p.pail p.pail mark.p.pail))}"
+          ;span.loaded: {<p.pail>}
+          ;span.loading
+            ;+  loading.feather-icons
+          ==
+        ==
+        ;div.pre.mono.scroll-x.p2
+          ;+  ;/
+          =/  size  (met 3 (jam q.q.pail))
+          ?:  (gth size 750)  "vase too large to print: {<size>}"
+          (of-wall:format (~(win re (sell q.pail)) 0 80))
+        ==
+      ==
+    ==
+    ;h2.bold.mt1: children
+    ;*
+    %+  murn  (flop (sort ~(tap by (~(kid of:neo kids.bowl) /)) aor))
+    |=  [=pith:neo *]
+    =/  heer  (welp here.bowl pith)
+    ?:  ?|
+          ::  ignored shrubs
+          ?=([[%p @] %cod %grab *] heer)
+          ?=([[%p @] %cod %grow *] heer)
+          :: ?=([[%p @] %cod %std %out *] heer)
+          ?=([[%p @] %cod %std %pre *] heer)
+          ?=([[%p @] %out *] heer)
+          ?=([[%p @] %srv *] heer)
+          ?=([[%p @] %sky *] heer)
+        ==
+      ~
+    :-  ~
+    =/  tape  (en-tape:pith:neo pith)
+    ;a.p2.b1.br1.bd1.hover.loader
+      =href  "/neo/hawk{(en-tape:pith:neo here.bowl)}{tape}"
+      ;span.loaded: {tape}
+      ;span.loading
+        ;+  loading.feather-icons
+      ==
+    ==
+  ==
+++  hawk
+  |_  [here=pith main=manx raw=manx has-app=? meta=[@da @ud]]
+  ++  our-tape
+    =/  f  (snag 0 here)
+    ?@(f (trip f) (scow f))
+  ++  id  -.meta
+  ++  slot  +.meta
+  ++  slot-tag
+    ::  XX  oh boy this is hacky.
+    ::  working with slots in ssr is tough
+    ?:  =(slot 999)  "s-1"
+    "s{<slot>}"
+  ++  idt  `tape`(zing (scan +:(scow %da id) (most dot (star ;~(less dot prn)))))
+  ++  vals
+    %^  cat  3  'js:{'
+    %^  cat  3  '"hawk-id": $(event?.target)?.closest("[slot]").attr("hawk-id") || "~2001.1.1"'
+    %^  cat  3  ', '
+    %^  cat  3  'slot: $(event?.target)?.closest("[slot]").attr("slot")?.slice(1) || "0"'
+    '}'
+  ++  lift
+    ^-  manx
+    ;div.hawk.fc.wf.hf.br1
+      =id  "hawk-{idt}"
+      =hawk-id  (scow %da id)
+      =slot  slot-tag
+      =hx-params  "hawk-id,slot"
+      =hx-vals  (trip vals)
+      =hx-target  "closest .hawk"
+      =hx-target-x  "closest .rendered"
+      =hx-target-404  "this"
+      ;+  header
+      ;div
+        =class  "raw wf hf b0 scroll-y scroll-x {(trip ?:(has-app 'hidden' ''))}"
+        ;+  raw
+      ==
+      ;div
+        =class  "rendered wf hf b0 scroll-y scroll-x {(trip ?:(has-app '' 'hidden'))}"
+        =id  "hawk-rendered-{idt}"
+        =morph-retain  "class"
+        ;+  main
+      ==
+    ==
+  ++  header
+    ;header.b2.frw.g1.ac
+      =id  "hawk-header-{idt}"
+      =style  "padding: 0 4px;"
+      ;button
+        =class  "p1 hover b2 br1 bd0 {(trip ?:(has-app '' 'toggled'))}"
+        =onclick
+          """
+          $(this).toggleClass('toggled');
+          $(this).closest('.hawk').find('.raw').toggleClass('hidden');
+          $(this).closest('.hawk').find('.rendered').toggleClass('hidden');
+          $(this).closest('header').children('.hawk-tog').toggleClass('hidden');
+          """
+        ;+  outline:feather-icons
+      ==
+      ;div
+        =class  "hawk-tog frw g1 ac grow {(trip ?:(has-app '' 'hidden'))}"
+        ;*
+          =<  p
+          %^  spin  here
+                0
+              |=  [=iota a=@]
+            :_  +(a)
+          =/  pad  ?:(=(a 0) "p-1" "p1")
+          ;div.fr.ac
+            =style  "height: 2rem;"
+            ;div.f4.s-2
+              ;+  chevron-right.feather-icons
+            ==
+            ;a
+              =class  "hover b2 {pad} s0 loader fc ac jc"
+              =style  "height: 2rem;"
+              =href  "/neo/hawk{(en-tape:pith:neo (scag +(a) here))}"
+              ;span.loaded
+                ;+  ;/
+                ?:  =(a 0)  "/"
+                (trip ?@(iota iota (scot iota)))
+              ==
+              ;span.loading
+                ;+  loading.feather-icons
+              ==
+            ==
+          ==
+        ;div.grow;
+      ==
+      ;form
+        =class  "hawk-tog grow fr ac m0 relative {(trip ?:(has-app 'hidden' ''))}"
+        =style  "height: 2rem;"
+        =hx-get  "/neo/hawk"
+        =hx-target  "closest .hawk"
+        ;div.absolute
+          =style  "top: 0.5rem; right: 0.5rem;"
+          ;div.loader
+            ;div.loaded(style "opacity: 0"): ---
+            ;div.loading
+              ;+  loading:feather-icons
+            ==
+          ==
+        ==
+        ;input.br1.b1.wf.s0.loaded.grow.bd0
+          =style  "margin-left: 5px; padding: 2px 4px;"
+          =type  "text"
+          =value  (en-tape:pith:neo here)
+          =oninput
+            """
+            $(this).attr('value', this.value);
+            $(this).parent().attr('hx-get', '/neo/hawk'+this.value);
+            htmx.process(document.body);
+            """
+          ;
+        ==
+      ==
+      ;div.fr.ac.jc.g1.hawk-actions
+        =id  "hawk-actions-{idt}"
+        =hx-ext  "ignore:html-enc"
+        ;button.p1.hover.b2.br1.loader.s-1
+          =hx-post  "/neo/hawk/{our-tape}/sky?stud=sky-diff&head=slide-up"
+          =hx-on-htmx-after-request
+            """
+            let swaper = $(this).closest('[slot]');
+            let slot = parseInt(swaper.attr('slot').slice(1));
+            let swapee = $(this).closest('a-i-r').find(`[slot='s$\{slot-1}']`);
+            if (swaper.length && swapee.length) \{
+              let ee = swapee.attr('slot');
+              let er = swaper.attr('slot');
+              swapee.attr('slot', er);
+              swaper.attr('slot', ee);
+            }
+            $(this).emit('hawks-moved');
+            """
+          =type  "button"
+          =hx-swap  "none"
+          ;span.loaded
+            ;+  chevron-left:feather-icons
+          ==
+          ;span.loading
+            ;+  loading.feather-icons
+          ==
+        ==
+        ;button.p1.hover.b2.br1.loader.s-1
+          =hx-post  "/neo/hawk/{our-tape}/sky?stud=sky-diff&head=slide-down"
+          =hx-on-htmx-after-request
+            """
+            let swaper = $(this).closest('[slot]');
+            let slot = parseInt(swaper.attr('slot').slice(1));
+            let swapee = $(this).closest('a-i-r').find(`[slot='s$\{slot+1}']`);
+            if (swaper.length && swapee.length) \{
+              let ee = swapee.attr('slot');
+              let er = swaper.attr('slot');
+              swapee.attr('slot', er);
+              swaper.attr('slot', ee);
+            }
+            $(this).emit('hawks-moved');
+            """
+          =hx-swap  "none"
+          =type  "button"
+          ;span.loaded
+            ;+  chevron-right:feather-icons
+          ==
+          ;span.loading
+            ;+  loading.feather-icons
+          ==
+        ==
+        ;button.p1.hover.b2.br1.loader.s-1
+          =hx-post  "/neo/hawk/{our-tape}/sky?stud=sky-diff&head=minimize"
+          =hx-swap  "none"
+          =type  "button"
+          =hx-on-htmx-after-request
+            """
+            let air = $(this).closest('a-i-r');
+            let now = parseInt(air.attr('hawks')) - 1;
+            air.attr('hawks', now);
+            $(this).closest('[slot]')[0].removeAttribute('slot');
+            $(this).emit('hawks-moved');
+            """
+          ;span.loaded
+            ;+  minimize:feather-icons
+          ==
+          ;span.loading
+            ;+  loading.feather-icons
+          ==
+        ==
+        ;style
+          ;+  ;/  %-  trip
+          '''
+          @media(max-width: 900px) {
+            .hawk-actions {
+              display: none !important;
+            }
+          }
+          '''
+        ==
+      ==
+    ==
+  --
+--

--- a/pkg/arvo/neo/cod/std/src/pro/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/blue.hoon
@@ -1,2 +1,3 @@
 $:  renderers=(map pith stud:neo)  :: default renderers
+    sessions=(map road:neo =task:eyre:neo)
 ==

--- a/pkg/arvo/neo/cod/std/src/pro/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/blue.hoon
@@ -1,0 +1,2 @@
+$:  renderers=(map pith stud:neo)  :: default renderers
+==

--- a/pkg/arvo/neo/cod/std/src/pro/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/blue.hoon
@@ -1,3 +1,3 @@
 $:  renderers=(map pith stud:neo)  :: default renderers
-    sessions=(map road:neo =task:eyre:neo)
+    sessions=(map road:neo eyre-id=@ta)
 ==

--- a/pkg/arvo/neo/cod/std/src/pro/blue.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/blue.hoon
@@ -1,3 +1,3 @@
 $:  renderers=(map pith stud:neo)  :: default renderers
-    sessions=(map road:neo eyre-id=@ta)
+    open-eyre-id=(unit @ta)
 ==

--- a/pkg/arvo/neo/cod/std/src/pro/renderer.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/renderer.hoon
@@ -1,0 +1,3 @@
+$:  session=road:neo
+    ui=(unit manx)
+==


### PR DESCRIPTION
`blue` is an experimental alternative to hawk that solves the problem described in #91. 

On your desktop, you can right-click a file and attempt to open it with any software on your computer. If the file matches the software's specification, this will succeed. 

`blue` thinks of renderers in the same way. A renderer is a shrub with a `deps` arm that (typically) expects a very specific implementation. The form of our `imp/diary` is:

```hoon
++  state
  [%pro %diary]
++  poke
  (sy %diary-diff ~)
++  kids
  %-  some
  :-  %y
  %-  ~(gas by *lads:neo)
  :~  :-  [[%.n %da] %.n]
      [[%only %txt] ~]
```

The deps arm of a diary renderer, then, will define:

```hoon
++  deps
  %-  ~(gas by *band:neo)
  :~  :-  %src
      ^-  fief:neo
      :-  req=&
      ^-  quay:neo
      :-  [pro/%diary (sy %diary-diff ~)]
      ^-  (unit port:neo)
      :+  ~  %y
      %-  ~(gas by *lads:neo)
      :~  :-  [[%.n %da] %.n]
          `lash:neo`[[%only %txt] ~]
      ==
  ==
```

`blue`'s state contains a map of `pith` to `stud`, with this stud representing a default renderer for the shrub at the pith. Upon receiving an HTTP request, `blue` will make the renderer, passing in the request as state and the pith as its dependency. The renderer then handles the request. 

(How this map gets populated is an open question and will be somewhat dependent on software distribution, but the desired user experience is, again, similar to your desktop, where the user might have to manually choose a renderer once, and then that renderer will be used for all shrubs of that type. URL parameters could be used to manually specify a renderer: `?renderer=some-renderer`)

For the devex of this to work, this means splitting out some parts of `hawk-eyre-handler`'s code into a library and absorbing other parts into the higher level request handler. This should conceptually feel very nice and necessary anyway, and overlaps a lot with the required work for sandboxing UIs within iframes.

Once this system of treating renderers as shrubs is working, we get `%make wizards` for free. Specify a `?wizard=some-wizard-renderer` URL parameter, and `blue` will create that rendering shrub (with no dependencies, since the shrub we're making doesn't exist yet). You could imagine a similar setup for embedding `tree` in Sky.

`blue` itself is an experiment and of course will have to merge with our other lines of work (request-response rewrite, iframes). This incomplete branch illustrates the concept.

To the extent that Sky has "apps," renderers are those apps. 

(Bonus: a renderer could allow multiple types of dependencies.)