### PR TITLE
%make wizards

### DIFF
--- a/pkg/arvo/neo/cod/std/src/imp/diary.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary.hoon
@@ -38,7 +38,7 @@
           ::  path contains any @da, and %.n is there
           ::  to signify that the pith can not have more
           ::  fields afterwards
-          [[%.n %da] %.n]
+          [[%.n %da] %.y]
       ::
       ::  lash:neo is (pair curb:neo (set stud:neo))
       ::  curb:neo defines the kids' state

--- a/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/hawk-eyre-handler.hoon
@@ -144,7 +144,7 @@
             ==
             ;div.b0.p-page.wf.hf.fc.g2.as
               ;a.p2.br1.bd1.b1.hover.loader.block
-                =href  "/neo/hawk{(spud pax.purl)}"
+                =href  "/neo/hawk{(spud (slag 1 pax.purl))}"
                 ;span.loaded: reload
                 ;span.loading
                   ;+  loading.feather-icons
@@ -207,7 +207,7 @@
             ==
             ;div.b0.p-page.wf.hf.fc.g2.as
               ;a.p2.br1.bd1.b1.hover.loader.block
-                =href  "/neo/hawk{(spud pax.purl)}"
+                =href  "/neo/hawk{(spud (slag 1 pax.purl))}"
                 ;span.loaded: reload
                 ;span.loading
                   ;+  loading.feather-icons

--- a/pkg/arvo/neo/cod/std/src/imp/hawk-eyre.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/hawk-eyre.hoon
@@ -31,7 +31,7 @@
         %+  ~(respond neo:srv eyre)   eyre-id
         (login-redirect:gen:srv request.req)
       =/  purl  (parse-url:serv request.req)
-      =/  inner=pith:neo  (pave:neo pax.purl)
+      =/  inner=pith:neo  (pave:neo (slag 1 pax.purl))
       =/  =crew:neo  (~(gas by *crew:neo) src/inner ~)
       =/  =made:neo  [%hawk-eyre-handler `[stud vax] crew]
       :_  sig/!>(~)
@@ -42,7 +42,7 @@
     |=  pal=(unit pail:neo)
     :_  sig/!>(~)
     =/  =pith:neo  #/[p/our.bowl]/$/eyre
-    =/  =binding:eyre  [~ ~[%neo %hawk]]
+    =/  =binding:eyre  [~ ~[%hawk]]
     =/  =req:eyre:neo  [%connect binding here.bowl]
     :~  [pith %poke eyre-req/!>(req)]
     ==

--- a/pkg/arvo/neo/cod/std/src/imp/nested-text.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/nested-text.hoon
@@ -1,0 +1,70 @@
+/@  txt
+::
+^-  kook:neo
+=<
+|%
+++  state  pro/%txt
+++  poke  ~
+++  kids
+  :+  ~  %y
+  %-  ~(gas by *lads:neo)
+  :~  :-  [|/%da |]
+      [pro/%txt ~]
+  ==
+++  deps  *deps:neo
+++  form
+  ^-  form:neo
+  |_  [=bowl:neo =aeon:neo state=pail:neo]
+  ++  init
+    |=  old=(unit pail:neo)
+    ^-  (quip card:neo pail:neo)
+    :_  (need old)
+    :~  :-  [p/our.bowl %wizard ~]
+        :+  %poke 
+          %wizard-poke
+        !>([%add-wizard %nested-text (wizard bowl)])
+    ==
+  ::
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    !!
+  --
+--
+::
+|%
+++  wizard
+  |=  =bowl:neo
+  ^-  manx
+  ;form.fc.g2
+    =style   "margin-bottom: 30px;"
+    =method  "post"
+    =action  "/wizard/nested-text/{(en-tape:pith:neo here.bowl)}"
+    ;textarea.p2.bd1.br1
+      =name  "pith"
+      =placeholder  "name"
+      =rows  "1"
+      ;
+    ==
+    ;textarea.hidden
+      =name  "stud"
+      =value  "%txt"
+      ;
+    ==
+    ;textarea.hidden
+      =name  "head-pail"
+      =value  "%txt"
+      ;
+    ==
+    ;textarea.p2.bd1.br1
+      =name  "vase"
+      =placeholder  "text"
+      =rows  "3"
+      ;
+    ==
+    ;button
+      =type  "submit"
+      ; Submit
+    ==
+  ==
+--

--- a/pkg/arvo/neo/cod/std/src/imp/nested-text.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/nested-text.hoon
@@ -46,7 +46,6 @@
       ;form.fc.g2
         =style   "margin-bottom: 30px;"
         =method  "post"
-        =action  "/wizard/nested-text{(en-tape:pith:neo here.bowl)}"
         ;input.p2.bd1.br1
           =name  "pith"
           =placeholder  "name"

--- a/pkg/arvo/neo/cod/std/src/imp/nested-text.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/nested-text.hoon
@@ -1,4 +1,5 @@
 /@  txt
+/-  srv=sky-server
 ::
 ^-  kook:neo
 =<
@@ -36,35 +37,43 @@
 ++  wizard
   |=  =bowl:neo
   ^-  manx
-  ;form.fc.g2
-    =style   "margin-bottom: 30px;"
-    =method  "post"
-    =action  "/wizard/nested-text/{(en-tape:pith:neo here.bowl)}"
-    ;textarea.p2.bd1.br1
-      =name  "pith"
-      =placeholder  "name"
-      =rows  "1"
-      ;
+  ;html
+    ;head
+      ;meta(charset "utf-8");
+      ;*  standard-head-tags:srv
     ==
-    ;textarea.hidden
-      =name  "stud"
-      =value  "%txt"
-      ;
-    ==
-    ;textarea.hidden
-      =name  "head-pail"
-      =value  "%txt"
-      ;
-    ==
-    ;textarea.p2.bd1.br1
-      =name  "vase"
-      =placeholder  "text"
-      =rows  "3"
-      ;
-    ==
-    ;button
-      =type  "submit"
-      ; Submit
+    ;body
+      ;form.fc.g2
+        =style   "margin-bottom: 30px;"
+        =method  "post"
+        =action  "/wizard/nested-text{(en-tape:pith:neo here.bowl)}"
+        ;input.p2.bd1.br1
+          =name  "pith"
+          =placeholder  "name"
+          =rows  "1"
+          ;
+        ==
+        ;input.hidden
+          =name  "stud"
+          =value  "%nested-txt"
+          ;
+        ==
+        ;input.hidden
+          =name  "head-pail"
+          =value  "%txt"
+          ;
+        ==
+        ;input.p2.bd1.br1
+          =name  "vase"
+          =placeholder  "text"
+          =rows  "3"
+          ;
+        ==
+        ;button
+          =type  "submit"
+          ; Submit
+        ==
+      ==
     ==
   ==
 --

--- a/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
@@ -398,12 +398,35 @@
   background: var(--b4);
   }
   @media (max-width: 900px) {
-  * {
-  font-size: calc(1.1 * var(--font-size));
-  }
-  input {
-  font-size: calc(0.9em * var(--mono-scale));
-  }
+    * {
+    font-size: calc(1.2 * var(--font-size));
+    }
+    input {
+    font-size: calc(1em * var(--mono-scale));
+    }
+    .top, .pro-btn, .import-btn, .buttons {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    }
+    .buttons, .form-btn {
+    display: flex;
+    justify-content: end;
+    }
+    .make-form, .poke-form, .cull-form, .part-make-form{
+    display: flex;
+    flex-direction: column;
+    }
+    .cull-btn{
+    justify-content: space-around;
+    }
+    .red-hover{
+    margin-top: 1rem;
+    background-color: #FF0000; 
+    color: var(--b0);
+    border-radius: 6px;
+    padding: 4px;
+    }
   }
   '''
 ::
@@ -451,14 +474,14 @@
   ;div
     ;div.fc.g2.bd.bd2.br2.p2
       ;div.top.fr.jb.g2
-        ;p.p2.hfc.wf.grow:  {(en-tape:pith:neo here)}
+        ;p.p2.hfc.wfh.grow:  {(en-tape:pith:neo here)}
         ;+  buttons
       ==
       ;div.fr.jb.g2
         ;+  ?.  =(p.pail %hoon)
           (state-print pail)
         empty-manx
-        ;div.fr.je.grow.g2
+        ;div.fr.je.grow.g2.pro-btn
           ;+  (pro-files pail here bowl)
           ;+  ?:  =(p.pail %$)
             empty-manx
@@ -525,7 +548,7 @@
     (scan (trip !<(@t q.pail)) (rein:ford:neo name))
   ?:  ?=(%| -.fool)  
     empty-manx
-  ;div.fr.g2
+  ;div.fr.g2.import-btn
     ;*  %+  turn  pro.p.fool
     |=  =pro:ford:neo
     ^-  manx
@@ -601,7 +624,7 @@
   =hx-post    "/neo/tree{(en-tape:pith:neo here)}?stud=tree-diff&head=send-make"
   =hx-swap    "outterHTML"
   =hx-target  ".error-box"
-    ;div.fr.g2
+    ;div.fr.g2.part-make-form
       ;input.hidden
       =type   "text"
       =name   "here"
@@ -637,7 +660,7 @@
       ;
       ==
     ==
-    ;div.fr.g2
+    ;div.fr.g2.part-make-form
       ;input.bd.bd2.br2.p2.grow
       =type          "text"
       =name          "vase"
@@ -654,9 +677,11 @@
       =required      ""
       ;
       ==
-      ;button.loader.bd.bd2.br2.hover-grey
-        ;span.loaded.p2:  make
-        ;span.loading.p2:  loading
+      ;div.form-btn
+        ;button.loader.bd.bd2.br2.hover-grey.p2
+          ;span.loaded.p2:  make
+          ;span.loading.p2:  loading
+        ==
       ==
     ==
   ==
@@ -692,9 +717,11 @@
     =required      ""
     ;
     ==
-    ;button.loader.bd.bd2.br2.hover-grey
-      ;span.loaded.p2:  poke
-      ;span.loading.p2:  loading
+    ;div.form-btn
+      ;button.loader.bd.bd2.br2.hover-grey.p2
+        ;span.loaded.p2:  poke
+        ;span.loading.p2:  loading
+      ==
     ==
   ==
 ::
@@ -708,11 +735,11 @@
     ;div.fc.ac
       ;p:  {warning}
     ==
-    ;div.fr.jc.g8.p2
+    ;div.fr.jc.g8.p2.cull-btn
       ;button.cull-trigger.hfc.p2.red-hover
       =name     "pith"
       =value    (en-tape:pith:neo here)
-        ;span:  yes
+        ;span.p2:  yes
       ==
       ;span.hfc.p2.red-hover.pointer
       =onclick  
@@ -720,7 +747,7 @@
       $(this).parent().parent().addClass('hidden');
       $(this).parent().parent().parent().parent().find('.top').find('.buttons').find('.cull').toggleClass('toggled');
       """
-        ;span:  no
+        ;span.p2:  no
       ==
     ==
   ==

--- a/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
@@ -134,11 +134,17 @@
           =.  status.resp  404
           =.  manx.resp  ;div:  not on your ship
           %-  eyre-cards  resp
-        =/  kids=(list pith:neo)  
-          %+  turn  (get-kids here q.src)
-            |=  =pith:neo
-            ;;  pith:neo
-            %+  slag  (lent here)  pith
+        =/  kids=(list pith:neo)  ~(tap in ~(key by (~(kid of:neo q.src) here)))
+        ::  
+        ::%+  turn 
+        ::  ~(tap in ~(key by (~(kid of:neo q.src) here)))
+        :: |=  p=pith:neo
+        :: (head p)
+        ~&  here
+          :: %+  turn  (get-kids here q.src)
+          ::   |=  =pith:neo
+          ::   ;;  pith:neo
+          ::   %+  slag  (lent here)  pith
         =.  manx.resp              
           ?~  idea=(~(get of:neo q.src) here)
             (view inner [%$ !>(~)] kids bowl)
@@ -159,20 +165,19 @@
           ::  %make cards don't have error(%goof) %acks yet 
           ::  sending eyre response here for now
           :_  eyre-id/!>(eyre-id)
-          =/  mule-vax=(each vase tang)
-            %-  mule  |.
-            %+  to-hoon  bowl
-            (get-by-name request 'vase') 
+          =/  mule-vax  (mule-vase bowl request)
           =/  mule-conf=(each conf:neo tang)
             %-  mule  |.  
             !<  conf:neo  
             %+  to-hoon  bowl
             (get-by-name request 'conf') 
-          ?:  ?=(%| -.mule-vax)
-            (poke-tree-card here.bowl !>([%req-parsing-err p.mule-vax]))
+          ?:  |(?=(%| -.mule-vax) ?=(%| -.mule-conf))
+          %+  poke-tree-card  here.bowl
+            !>  :-  %req-parsing-err
+            ?:  ?=(%| -.mule-vax)
+              p.mule-vax
+            p.mule-conf
           =/  vax=vase  p.mule-vax
-          ?:  ?=(%| -.mule-conf)
-            (poke-tree-card here.bowl !>([%req-parsing-err p.mule-conf]))
           =/  =conf:neo  p.mule-conf
           =+  diff=tree-diff
           =.  init.diff
@@ -190,10 +195,7 @@
           ::
             %send-poke
           :_  eyre-id/!>(eyre-id)  
-          =/  mule-vax
-            %-  mule  |.
-            %+  to-hoon  bowl
-            (get-by-name request 'vase')
+          =/  mule-vax  (mule-vase bowl request)
           ?-  -.mule-vax
               %|  
             (poke-tree-card here.bowl !>([%req-parsing-err p.mule-vax]))
@@ -280,6 +282,13 @@
   =/  kid-pith  !<  pith:neo  (to-hoon bowl kid)
   (welp parent kid-pith)
 ::
+++  mule-vase
+  |=  [=bowl:neo req=request:http]
+  ^-  (each vase tang)
+  %-  mule  |.
+  %+  to-hoon  bowl
+  (get-by-name req 'vase') 
+::
 ++  get-by-name
   |=  [req=request:http hoon=cord]
   ^-  cord
@@ -301,7 +310,7 @@
     ;*  %+  turn  tang
       |=  =tank
       ^-  manx
-      ;div.wf.fr.js.p1.error.monospace
+      ;div.wf.fr.js.p1.error.mono
         ;  {~(ram re tank)}
       ==
   ==
@@ -343,6 +352,7 @@
   ==
 ::
 ++  tree-style 
+    :: font-size: calc(2 * var(--font-size));
   ^~
   %-  trip 
   '''
@@ -352,37 +362,48 @@
   font-style: normal;
   font-weight: 600;
   }
+  :root {
+  --font: 'Urbit Sans', normal;
+  }
+  *{
+  font-size: calc(1.2 * var(--font-size));
+  }
   body{
-  font-family: 'Urbit Sans';
-  font-size: 15px;
+  font-family: var(--font);
+  background: var(--b0);
+  color: var(--f0);
   }
   input{
-  font-family: 'monospace', monospace;
-  font-size: 13px;
-  }
-  .monospace{
-  font-family: 'monospace', monospace;
-  font-size: 13px;
+  font-family: var(--font-mono);
+  font-size: calc(1em * var(--mono-scale));
   }
   .red-hover:hover{
   background-color: #FF0000; 
-  color: white;
+  color: var(--b0);
   border-radius: 6px;
   }
   .pointer{
   cursor: pointer;
   }
   .bd.bd2{
-  border: 0.8px solid black;
+  border: 1.2px solid var(--f1);
   }
   .error{
   color: #FF0000; 
   }
   .bg-white{
-  background: white;
+  background: var(--b2);
   }
   .hover-grey:hover{
-  background: #dbdbdb;
+  background: var(--b4);
+  }
+  @media (max-width: 900px) {
+  * {
+  font-size: calc(1.1 * var(--font-size));
+  }
+  input {
+  font-size: calc(0.9em * var(--mono-scale));
+  }
   }
   '''
 ::
@@ -479,13 +500,13 @@
   ^-  manx
   ?:  =(p.pail %hoon)
     =/  wain=(list @t)  (to-wain:format !<(@t q.pail))
-    ;div.fc.g1.p2.grow.monospace
+    ;div.fc.g1.p2.grow
       ;* 
       %+  turn  wain
       |=  lin=@t 
-      ;p.monospace:  {(trip lin)}\0a
+      ;p.mono:  {(trip lin)}\0a
     ==
-  ;div.fr.js.p2.monospace
+  ;div.fr.js.p2.mono
     ;+  ;/
     =/  size  (met 3 (jam q.q.pail))
     ?:  (gth size 750)  "vase too large to print: {<size>}"
@@ -529,7 +550,7 @@
       $(this).parent().parent().parent().find('.cull-form').addClass('hidden');
       $(this).parent().parent().parent().find('.error-box').html('')
       """
-      ;span:  poke
+      ;span.p2:  poke
     ==
     ;button.cull.p2.bd.bd2.br2.hover-grey.bg-white
     =onclick  
@@ -542,7 +563,7 @@
       $(this).parent().parent().parent().find('.poke-form').addClass('hidden');
       $(this).parent().parent().parent().find('.error-box').html('')
       """
-      ;span:  cull
+      ;span.p2:  cull
     ==
   ==
 ::
@@ -558,7 +579,7 @@
     $(this).parent().parent().parent().find('.poke-form').addClass('hidden');
     $(this).parent().parent().parent().find('.error-box').html('')
     """
-    ;span:  make
+    ;span.p2:  make
   ==
 ::
 ++  forms

--- a/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
@@ -2,6 +2,7 @@
 /@  tree-diff
 /-  serv=sky-server
 /-  srv=server
+/-  su=shrub-utils
 /*  feather
 /*  reset
 /*  jquery
@@ -134,17 +135,7 @@
           =.  status.resp  404
           =.  manx.resp  ;div:  not on your ship
           %-  eyre-cards  resp
-        =/  kids=(list pith:neo)  ~(tap in ~(key by (~(kid of:neo q.src) here)))
-        ::  
-        ::%+  turn 
-        ::  ~(tap in ~(key by (~(kid of:neo q.src) here)))
-        :: |=  p=pith:neo
-        :: (head p)
-        ~&  here
-          :: %+  turn  (get-kids here q.src)
-          ::   |=  =pith:neo
-          ::   ;;  pith:neo
-          ::   %+  slag  (lent here)  pith
+        =/  kids=(list pith:neo)  (kids-at-pith:su q.src here)
         =.  manx.resp              
           ?~  idea=(~(get of:neo q.src) here)
             (view inner [%$ !>(~)] kids bowl)
@@ -267,7 +258,7 @@
   |=  [parent=pith:neo =lore:neo]
   ^-  (list pith:neo)
   ?~  (~(kid of:neo lore) parent)  ~
-  %+  turn  ~(tap in ~(key by (~(kid of:neo lore) parent)))  
+  %+  turn  (kids-at-pith:su lore parent)
     |=  p=pith:neo 
     %+  welp  parent  p
 ::
@@ -344,7 +335,7 @@
     ;style: {(trip feather)}
     ;style: {tree-style}
     ==
-    ;body 
+    ;body
       ;+  ?:  &(=(kids ~) =(pail [%$ !>(~)]))
         (nothing-view here)
       (body-view here pail kids bowl)
@@ -352,26 +343,11 @@
   ==
 ::
 ++  tree-style 
-    :: font-size: calc(2 * var(--font-size));
   ^~
   %-  trip 
   '''
-  @font-face {
-  font-family: 'Urbit Sans';
-  src: url("https://media.urbit.org/fonts/UrbitSans/UrbitSansVFWeb-Regular.woff2") format("woff2");
-  font-style: normal;
-  font-weight: 600;
-  }
-  :root {
-  --font: 'Urbit Sans', normal;
-  }
   *{
   font-size: calc(1.2 * var(--font-size));
-  }
-  body{
-  font-family: var(--font);
-  background: var(--b0);
-  color: var(--f0);
   }
   input{
   font-family: var(--font-mono);
@@ -382,20 +358,11 @@
   color: var(--b0);
   border-radius: 6px;
   }
-  .pointer{
-  cursor: pointer;
-  }
   .bd.bd2{
   border: 1.2px solid var(--f1);
   }
   .error{
   color: #FF0000; 
-  }
-  .bg-white{
-  background: var(--b2);
-  }
-  .hover-grey:hover{
-  background: var(--b4);
   }
   @media (max-width: 900px) {
     * {
@@ -412,10 +379,6 @@
     .buttons, .form-btn {
     display: flex;
     justify-content: end;
-    }
-    .make-form, .poke-form, .cull-form, .part-make-form{
-    display: flex;
-    flex-direction: column;
     }
     .cull-btn{
     justify-content: space-around;
@@ -439,7 +402,7 @@
       ;div.top.fr.jb.g2.wf
         ;h1.p2:  nothing at {(en-tape:pith:neo here)}
         ;div.buttons.fr.g2
-          ;a.loader.p2.tc.hover-grey.bd.bd2.br2.grow
+          ;a.loader.p2.tc.hover.b0.bd.bd2.br2.grow
           =href  "/neo/tree{parent}"
             ;span.loaded.hf: back to {parent}
             ;span.loading.hf:  loading
@@ -485,7 +448,7 @@
           ;+  (pro-files pail here bowl)
           ;+  ?:  =(p.pail %$)
             empty-manx
-          ;a.loader.p2.bd.bd2.br2.hover-grey
+          ;a.loader.p2.bd.bd2.br2.hover.b0
           =href  "/neo/tree/{(scow %p our.bowl)}/cod/std/src/pro/{(trip ?@(p.pail p.pail mark.p.pail))}"
             ;span.loaded.hf: {<p.pail>}
             ;span.loading.hf:  loading
@@ -510,7 +473,7 @@
     ^-  manx
     ?~  pith  
       empty-manx
-    ;a.fr.jb.g1.bd.bd2.br2.hover-grey
+    ;a.fr.jb.g1.bd.bd2.br2.hover.b0
     =href  "/neo/tree{(en-tape:pith:neo (weld here pith))}"
       ;div.p2.hfc.p2.hover
         ;  {(en-tape:pith:neo pith)}
@@ -552,7 +515,7 @@
     ;*  %+  turn  pro.p.fool
     |=  =pro:ford:neo
     ^-  manx
-    ;a.loader.bd.bd2.br2.p2.hover-grey
+    ;a.loader.bd.bd2.br2.p2.hover.b0
       =href  "/neo/tree/{(scow %p our.bowl)}/cod/std/src/pro/{(trip ?@(stud.pro stud.pro mark.stud.pro))}"
         ;span.loaded.hfc: {<stud.pro>}
         ;span.loading.hfc:  loading
@@ -562,7 +525,7 @@
   ^-  manx
   ;div.buttons.fr.g2
     ;+  make-btn
-    ;button.poke.p2.bd.bd2.br2.hover-grey.bg-white
+    ;button.poke.p2.bd.bd2.br2.hover.b2
     =onclick  
       """
       $(this).toggleClass('toggled');
@@ -575,7 +538,7 @@
       """
       ;span.p2:  poke
     ==
-    ;button.cull.p2.bd.bd2.br2.hover-grey.bg-white
+    ;button.cull.p2.bd.bd2.br2.hover.b2
     =onclick  
       """
       $(this).toggleClass('toggled');
@@ -591,7 +554,7 @@
   ==
 ::
 ++  make-btn
-  ;button.make.p2.bd.bd2.br2.hover-grey.bg-white
+  ;button.make.p2.bd.bd2.br2.hover.b2
   =onclick  
     """
     $(this).toggleClass('toggled');
@@ -624,7 +587,7 @@
   =hx-post    "/neo/tree{(en-tape:pith:neo here)}?stud=tree-diff&head=send-make"
   =hx-swap    "outterHTML"
   =hx-target  ".error-box"
-    ;div.fr.g2.part-make-form
+    ;div.frw.g2
       ;input.hidden
       =type   "text"
       =name   "here"
@@ -643,7 +606,7 @@
       =placeholder   "/some/pith"
       ;
       ==
-      ;input.bd.bd2.br2.p2 
+      ;input.bd.bd2.br2.p2.grow
       =type          "text"
       =name          "stud"
       =oninput       "this.setAttribute('value', this.value);"
@@ -651,7 +614,7 @@
       =required      ""
       ;
       ==
-      ;input.bd.bd2.br2.p2 
+      ;input.bd.bd2.br2.p2.grow
       =type          "text"
       =name          "head-pail"
       =oninput       "this.setAttribute('value', this.value);"
@@ -660,7 +623,7 @@
       ;
       ==
     ==
-    ;div.fr.g2.part-make-form
+    ;div.frw.g2
       ;input.bd.bd2.br2.p2.grow
       =type          "text"
       =name          "vase"
@@ -678,7 +641,7 @@
       ;
       ==
       ;div.form-btn
-        ;button.loader.bd.bd2.br2.hover-grey.p2
+        ;button.loader.bd.bd2.br2.hover.b0.p2
           ;span.loaded.p2:  make
           ;span.loading.p2:  loading
         ==
@@ -689,7 +652,7 @@
 ++  poke-form
   |=  here=pith:neo
   ^-  manx
-  ;form.poke-form.hidden.bd.bd2.br2.fr.jb.g2.p2.wf
+  ;form.poke-form.hidden.bd.bd2.br2.frw.jb.g2.p2.wf
   =hx-post    "/neo/tree{(en-tape:pith:neo here)}?stud=tree-diff&head=send-poke"
   =hx-swap    "outterHTML"
   =hx-target  ".error-box"
@@ -718,7 +681,7 @@
     ;
     ==
     ;div.form-btn
-      ;button.loader.bd.bd2.br2.hover-grey.p2
+      ;button.loader.bd.bd2.br2.hover.b0.p2
         ;span.loaded.p2:  poke
         ;span.loading.p2:  loading
       ==

--- a/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/tree-eyre.hoon
@@ -38,7 +38,7 @@
     |=  pal=(unit pail:neo)
     :_  eyre-id/!>(*@ta)
     =/  =pith:neo  #/[p/our.bowl]/$/eyre
-    =/  =binding:eyre  [~ ~[%neo %tree]]
+    =/  =binding:eyre  [~ ~[%tree]]
     =/  =req:eyre:neo  [%connect binding here.bowl]
     :~  [pith %poke eyre-req/!>(req)]
     ==
@@ -116,7 +116,7 @@
         %+  ~(respond neo:srv eyre)   eyre-id
         (login-redirect:gen:srv request)
       =/  purl  (parse-url:serv request)
-      =/  inner=pith:neo  (pave:neo pax.purl)
+      =/  inner=pith:neo  (pave:neo (slag 1 pax.purl))
       =/  src  (~(got by deps.bowl) %src)
       =/  here  (tail inner)
       =+  ^=  resp

--- a/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
@@ -2,6 +2,7 @@
 /@  wizard-poke
 /-  serv=sky-server
 /-  srv=server
+/-  manx-utils
 =<
 ^-  kook:neo
 |%
@@ -15,7 +16,7 @@
     |=  pal=(unit pail:neo)
     :_  wizard/!>(~)
     =/  =pith:neo  #/[p/our.bowl]/$/eyre
-    =/  =binding:eyre  [~ ~[%neo %wizard]]
+    =/  =binding:eyre  [~ ~[%wizard]]
     =/  =req:eyre:neo  [%connect binding here.bowl]
     :~  [pith %poke eyre-req/!>(req)]
     ==
@@ -38,22 +39,20 @@
       :_  pail
       =+  !<(=task:eyre:neo vax)
       =/  [eyre-id=@ta req=inbound-request:eyre]  task
-      =/  request=request:http  request.req
       ?.  authenticated.req
         %+  ~(respond neo:srv #/[p/our.bowl]/$/eyre)
           eyre-id
-        (login-redirect:gen:srv request)
+        (login-redirect:gen:srv request.req)
       =/  purl  (parse-url:serv request.req)
-      =/  =pith:neo  (pave:neo pax:purl)
-      ?+    method.request  ~|(%unsupported-http-method !!)
+      =/  the-pith  (pave:neo pax:purl)
+      ?+    method.request.req  ~|(%unsupported-http-method !!)
         ::
         ::  Serve either the wizard chooser
         ::  or a specific wizard.
           %'GET'
-        ~&  >  pith
-        =/  renderer  (snag 1 pith)
+        ~&  >  the-pith
+        =/  renderer  (snag 1 the-pith)
         ~&  >  renderer
-        ?^  renderer  ~|('Second iota in URL must be a @tas.' !!)
         =+  #/[p/our.bowl]/$/eyre
         :~  (head-card - eyre-id)
         ::
@@ -65,31 +64,81 @@
                   %data
                 :-  ~
                 %-  manx-to-octs
-                ?:  =(~ renderer)
+                ?:  =([%n ~] renderer)
                   chooser
+                ?^  renderer  
+                  ~|('Second iota in URL must be a @tas.' !!)
                 (~(got by state) renderer)
             ==
         ::
             (done-card - eyre-id)
         ==
         ::
-        ::  Unpack into a made:neo, %make it,
+        ::  Unpack request into a made:neo, %make it,
         ::  and then redirect to tree/new-shrub.
           %'POST'
-        ~
-        ::=/  name  ::  XX ensure they encode this too
-        ::=/  loc  (weld pith name)
-        :::~  :*  (weld pith name)
-        ::        %make
-        ::        (~(got by pam.purl) 'made')  :: XX what style of encoding feels good here?
-        ::    ==
-        
-        :::~  (head-card - eyre-id)
-        ::    (redirect:srv (crip (en-tape:pith:neo loc)))
-        ::    (done-card - eyre-id)
-        ::==
-        
-        ::==
+        =/  body=(map @t @t)
+          (parse-form-body:serv request.req)
+        ::
+        =/  name=pith
+          %-  pave:neo
+          %-  stab
+          (~(got by body) 'pith')
+        =/  loc=pith
+          %+  weld 
+            (oust [0 2] the-pith)
+          name
+        ::
+        =/  stud=@tas
+          !<  @tas
+          %+  slap
+            !>(~)
+          %-  ream
+          (~(got by body) 'stud')
+        ::
+        =/  head-pail=@tas
+          !<  @tas
+          %+  slap
+            !>(~)
+          %-  ream
+          (~(got by body) 'head-pail')
+        ::
+        =/  vase=vase
+          %+  slap  
+            !>(..zuse)
+          %-  ream 
+          (~(got by body) 'vase')
+        ::
+        =/  conf=conf:neo
+          =/  c  (~(get by body) 'vase')
+          ?~  c  ~
+          !<  conf:neo  
+          %+  slap  
+            !>(..zuse)
+          %-  ream 
+          (need c)
+        ::
+        =+  #/[p/our.bowl]/$/eyre
+        :~  :*  loc
+                %make
+                stud
+                [~ head-pail vase]
+                conf
+            ==
+          ::
+            (head-card - eyre-id)
+          ::
+            :*  -
+                %poke
+                %eyre-sign
+                !>
+                :+  eyre-id
+                  %data
+                (redirect:gen:srv (crip (en-tape:pith:neo loc)))
+            ==
+          ::
+            (done-card - eyre-id)
+        ==
       ==
     ==
   --

--- a/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
@@ -50,9 +50,7 @@
         ::  Serve either the wizard chooser
         ::  or a specific wizard.
           %'GET'
-        ~&  >  the-pith
         =/  renderer  (snag 1 the-pith)
-        ~&  >  renderer
         =+  #/[p/our.bowl]/$/eyre
         :~  (head-card - eyre-id)
         ::
@@ -65,7 +63,7 @@
                 :-  ~
                 %-  manx-to-octs
                 ?:  =([%n ~] renderer)
-                  chooser
+                  (chooser [~(key by state) the-pith])
                 ?^  renderer  
                   ~|('Second iota in URL must be a @tas.' !!)
                 (~(got by state) renderer)
@@ -80,14 +78,14 @@
         =/  body=(map @t @t)
           (parse-form-body:serv request.req)
         ::
-        =/  name=pith
-          %-  pave:neo
-          %-  stab
-          (~(got by body) 'pith')
         =/  loc=pith
           %+  weld 
             (oust [0 2] the-pith)
-          name
+          !<  pith:neo
+          %+  slap  
+            !>(..zuse)
+          %-  ream 
+          (~(got by body) 'pith')
         ::
         =/  stud=@tas
           !<  @tas
@@ -110,7 +108,7 @@
           (~(got by body) 'vase')
         ::
         =/  conf=conf:neo
-          =/  c  (~(get by body) 'vase')
+          =/  c  (~(get by body) 'conf')
           ?~  c  ~
           !<  conf:neo  
           %+  slap  
@@ -118,26 +116,16 @@
           %-  ream 
           (need c)
         ::
-        =+  #/[p/our.bowl]/$/eyre
+        %+  welp
+          %+  ~(respond neo:srv #/[p/our.bowl]/$/eyre)
+            eyre-id
+          (redirect:gen:srv (en-cord:pith:neo (welp #/tree loc)))
         :~  :*  loc
                 %make
                 stud
                 [~ head-pail vase]
                 conf
             ==
-          ::
-            (head-card - eyre-id)
-          ::
-            :*  -
-                %poke
-                %eyre-sign
-                !>
-                :+  eyre-id
-                  %data
-                (redirect:gen:srv (crip (en-tape:pith:neo loc)))
-            ==
-          ::
-            (done-card - eyre-id)
         ==
       ==
     ==
@@ -166,14 +154,41 @@
   (as-octt:mimes:html (en-xml:html man))
 ::
 ++  chooser
+  |=  [options=(set stud:neo) the-pith=pith]
+  ::=/  oninput
+  ::  """
+  ::  this.setAttribute("value", this.value); 
+  ::  this.nextElementSibling.nextElementSibling.setAttribute('action', '/wizard/' + this.value + {(en-tape:pith:neo (oust [0 2] the-pith))}); 
+  ::  """
   ;html
     ;head
       ;meta(charset "UTF-8");
       ;title: Wizards
+      ;*  standard-head-tags:serv
     ==
     ;body
-      ;p
-        ; Placeholder  :: XX dropdown goes here
+      ;form
+        =method  "get"
+        =action  "/wizard/nested-text{(en-tape:pith:neo (oust [0 2] the-pith))}"
+        ::  /wizard/input-value/(oust [0 2] the-pith)
+        ;select
+          =name  "choice"
+          :: =oninput  oninput
+          ;*
+          %+  turn
+            ~(tap in options)
+          |=  =stud:neo
+          ?^  stud  :: XX will need to change this someday
+            ~|("The stud you chose isn't a @tas. Let the devs know if you ever see this error." !!)
+          ^-  manx
+          ;option  
+            {(trip stud)}
+          ==
+        ==
+        ;button
+          =type  "submit"
+          ; Submit
+        ==
       ==
     ==
   ==

--- a/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
@@ -157,11 +157,6 @@
 ::
 ++  chooser
   |=  [options=(set stud:neo) the-pith=pith]
-  ::=/  oninput
-  ::  """
-  ::  this.setAttribute("value", this.value); 
-  ::  this.nextElementSibling.nextElementSibling.setAttribute('action', '/wizard/' + this.value + {(en-tape:pith:neo (oust [0 2] the-pith))}); 
-  ::  """
   ;html
     ;head
       ;meta(charset "UTF-8");
@@ -169,28 +164,22 @@
       ;*  standard-head-tags:serv
     ==
     ;body
-      ;form
-        =method  "get"
-        =action  "/wizard/nested-text{(en-tape:pith:neo (oust [0 2] the-pith))}"
-        ::  /wizard/input-value/(oust [0 2] the-pith)
-        ;select
-          =name  "choice"
-          :: =oninput  oninput
-          ;*
-          %+  turn
-            ~(tap in options)
-          |=  =stud:neo
-          ?^  stud  :: XX will need to change this someday
-            ~|("The stud you chose isn't a @tas. Let the devs know if you ever see this error." !!)
-          ^-  manx
-          ;option  
-            {(trip stud)}
-          ==
+      ;*
+      %+  turn
+        ~(tap in options)
+      |=  =stud:neo
+      ?^  stud  :: XX will need to change this someday
+        ~|("The stud you chose isn't a @tas. Let the devs know if you ever see this error." !!)
+      ^-  manx
+      =/  link=tape
+        ;:  welp 
+          "/wizard/" 
+          (trip stud) 
+          (en-tape:pith:neo (oust [0 2] the-pith))
         ==
-        ;button
-          =type  "submit"
-          ; Submit
-        ==
+      ;a
+        =href  link
+        ; {(trip stud)} 
       ==
     ==
   ==

--- a/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
@@ -78,6 +78,7 @@
         =/  body=(map @t @t)
           (parse-form-body:serv request.req)
         ::
+        ~&  >  the-pith
         =/  loc=pith
           %+  weld 
             (oust [0 2] the-pith)
@@ -86,6 +87,7 @@
             !>(..zuse)
           %-  ream 
           (~(got by body) 'pith')
+        ~&  >  loc
         ::
         =/  stud=@tas
           !<  @tas

--- a/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
@@ -121,7 +121,7 @@
         %+  welp
           %+  ~(respond neo:srv #/[p/our.bowl]/$/eyre)
             eyre-id
-          (redirect:gen:srv (en-cord:pith:neo (welp #/tree loc)))
+          [[301 ['location' (en-cord:pith:neo (welp #/tree loc))]~] ~]
         :~  :*  loc
                 %make
                 stud

--- a/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/wizard.hoon
@@ -1,0 +1,131 @@
+/@  wizard
+/@  wizard-poke
+/-  serv=sky-server
+/-  srv=server
+=<
+^-  kook:neo
+|%
+++  state  pro/%wizard
+++  poke   (sy %wizard-poke %eyre-task ~)
+++  kids  *kids:neo
+++  deps   *deps:neo
+++  form
+  |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  init
+    |=  pal=(unit pail:neo)
+    :_  wizard/!>(~)
+    =/  =pith:neo  #/[p/our.bowl]/$/eyre
+    =/  =binding:eyre  [~ ~[%neo %wizard]]
+    =/  =req:eyre:neo  [%connect binding here.bowl]
+    :~  [pith %poke eyre-req/!>(req)]
+    ==
+  ::
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    =/  state  !<(wizard q.pail)
+    ?+    stud  ~|(bad-stud/stud !!)
+        %wizard-poke
+      =/  poke  !<(wizard-poke vax)
+      ?-    -.poke
+          %add-wizard
+        [~ wizard/!>((~(put by state) stud.poke manx.poke))]
+          %del-wizard
+        [~ wizard/!>((~(del by state) stud.poke))]
+      ==
+    ::
+        %eyre-task
+      :_  pail
+      =+  !<(=task:eyre:neo vax)
+      =/  [eyre-id=@ta req=inbound-request:eyre]  task
+      =/  request=request:http  request.req
+      ?.  authenticated.req
+        %+  ~(respond neo:srv #/[p/our.bowl]/$/eyre)
+          eyre-id
+        (login-redirect:gen:srv request)
+      =/  purl  (parse-url:serv request.req)
+      =/  =pith:neo  (pave:neo pax:purl)
+      ?+    method.request  ~|(%unsupported-http-method !!)
+        ::
+        ::  Serve either the wizard chooser
+        ::  or a specific wizard.
+          %'GET'
+        ~&  >  pith
+        =/  renderer  (snag 1 pith)
+        ~&  >  renderer
+        ?^  renderer  ~|('Second iota in URL must be a @tas.' !!)
+        =+  #/[p/our.bowl]/$/eyre
+        :~  (head-card - eyre-id)
+        ::
+            :*  - 
+                %poke 
+                %eyre-sign
+                !>
+                :+  eyre-id 
+                  %data
+                :-  ~
+                %-  manx-to-octs
+                ?:  =(~ renderer)
+                  chooser
+                (~(got by state) renderer)
+            ==
+        ::
+            (done-card - eyre-id)
+        ==
+        ::
+        ::  Unpack into a made:neo, %make it,
+        ::  and then redirect to tree/new-shrub.
+          %'POST'
+        ~
+        ::=/  name  ::  XX ensure they encode this too
+        ::=/  loc  (weld pith name)
+        :::~  :*  (weld pith name)
+        ::        %make
+        ::        (~(got by pam.purl) 'made')  :: XX what style of encoding feels good here?
+        ::    ==
+        
+        :::~  (head-card - eyre-id)
+        ::    (redirect:srv (crip (en-tape:pith:neo loc)))
+        ::    (done-card - eyre-id)
+        ::==
+        
+        ::==
+      ==
+    ==
+  --
+--
+::
+|%
+++  head-card
+  |=  [=pith eyre-id=@ta]
+  :*  pith
+      %poke 
+      %eyre-sign
+      !>
+      :^    eyre-id
+          %head 
+        200
+      ['content-type' 'text/html']~
+  ==
+::
+++  done-card
+  |=  [=pith eyre-id=@ta]
+  [pith %poke eyre-sign/!>([eyre-id %done ~])]
+::
+++  manx-to-octs
+  |=  man=manx
+  (as-octt:mimes:html (en-xml:html man))
+::
+++  chooser
+  ;html
+    ;head
+      ;meta(charset "UTF-8");
+      ;title: Wizards
+    ==
+    ;body
+      ;p
+        ; Placeholder  :: XX dropdown goes here
+      ==
+    ==
+  ==
+--

--- a/pkg/arvo/neo/cod/std/src/lib/shrub-utils.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/shrub-utils.hoon
@@ -38,12 +38,19 @@
 ::
 ::  (unit pail) from lore 
 ::
-++  pail-from-lore
+++  get-pail-by-pith
   |=  [=lore:neo =pith:neo]
   ^-  (unit pail:neo)
-  =/  id=(unit idea:neo)  (~(get of:neo lore) pith)
-  ?~  id  ~
-  `q.saga:(need id)
+  =/  idea=(unit idea:neo)  (~(get of:neo lore) pith)
+  ?~  idea  ~
+  `pail:(need idea)
+::
+++  get-vase-by-pith
+  |=  [=lore:neo =pith:neo]
+  ^-  (unit vase)
+  =/  idea=(unit idea:neo)  (~(get of:neo lore) pith)
+  ?~  idea  ~
+  `q.pail:(need idea)
 ::
 ::  get pail.saga from idea 
 ::  
@@ -51,4 +58,21 @@
 ::   |=  =idea:neo
 ::   ^-  pail:neo
 ::   q.saga:(need idea)
+::
+++  en-pith
+  |=  =cord
+  ^-  pith
+  %-  pave:neo
+  ;;  path
+  %-  stub  cord
+::
+:: ???
+::
+++  en-tape-mast
+  |=  [vm=@tas =pith:neo]
+  ^-  tape
+  %-  en-tape:pith:neo
+  %+  welp  /[vm]
+  pith
+::
 --

--- a/pkg/arvo/neo/cod/std/src/lib/shrub-utils.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/shrub-utils.hoon
@@ -28,7 +28,7 @@
 ::
 ::  list of kids piths from lore with full pith
 ::
-++  kids-full-pith
+++  full-pith
   |=  [parent=pith:neo =lore:neo]
   ^-  (list pith:neo)
   ?~  (~(kid of:neo lore) parent)  ~

--- a/pkg/arvo/neo/cod/std/src/lib/shrub-utils.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/shrub-utils.hoon
@@ -1,0 +1,54 @@
+|%  
+::
+::  get list of kids piths from lore
+::
+++  kids-at-pith
+  |=  [=lore:neo =pith:neo]
+  ^-  (list pith:neo) 
+  %~  tap  in 
+  %~  key  by
+  %-  %~  kid  of:neo
+      lore
+  pith
+::
+::  list of kids piths from lore as care %z
+::
+++  kidz-at-pith
+  |=  [=pith:neo =lore:neo]
+  =|  i=@
+  ^-  (list pith:neo)
+  =+  piths=(full-pith pith lore)
+  |-
+  ?:  =(i (lent piths))  piths
+    =/  p=pith:neo  (snag i piths)
+    ?~  (~(kid of:neo lore) p)  
+      $(i +(i))
+    =/  grand-kids  (full-pith p lore)
+    $(i +(i), piths (welp piths grand-kids))
+::
+::  list of kids piths from lore with full pith
+::
+++  kids-full-pith
+  |=  [parent=pith:neo =lore:neo]
+  ^-  (list pith:neo)
+  ?~  (~(kid of:neo lore) parent)  ~
+  %+  turn  ~(tap in ~(key by (~(kid of:neo lore) parent)))  
+    |=  p=pith:neo 
+    %+  welp  parent  p
+::
+::  (unit pail) from lore 
+::
+++  pail-from-lore
+  |=  [=lore:neo =pith:neo]
+  ^-  (unit pail:neo)
+  =/  id=(unit idea:neo)  (~(get of:neo lore) pith)
+  ?~  id  ~
+  `q.saga:(need id)
+::
+::  get pail.saga from idea 
+::  
+:: ++  pail-from-idea
+::   |=  =idea:neo
+::   ^-  pail:neo
+::   q.saga:(need idea)
+--

--- a/pkg/arvo/neo/cod/std/src/lib/sky-server.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/sky-server.hoon
@@ -20,8 +20,7 @@
         ;~(pfix fas (more fas smeg:de-purl:html))
         yque:de-purl:html
     ==
-      :: strip first 2 segments (/neo/hawk)
-  :-  (slag 2 -.parsed)
+  :-  -.parsed
   (~(uni by (malt +.parsed)) (malt header-list.request))
 ++  parse-body
   |=  =request:http

--- a/pkg/arvo/neo/cod/std/src/pro/wizard-poke.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/wizard-poke.hoon
@@ -1,0 +1,3 @@
+$%  [%add-wizard =stud:neo =manx]
+    [%del-wizard =stud:neo]
+==

--- a/pkg/arvo/neo/cod/std/src/pro/wizard.hoon
+++ b/pkg/arvo/neo/cod/std/src/pro/wizard.hoon
@@ -1,0 +1,1 @@
+(map stud:neo manx)


### PR DESCRIPTION
`wizard` is a rendering framework for serving `%make` wizards to the user. 

This code still needs some production work to be fully functional, but the idea is:

- While browsing any path (for instance, `/~met/home/tasks`), the user chooses `wizard` from Sky's renderer/overlay dropdown. An HTTP request is sent to `/wizard/~/~met/home/tasks`.
- `%wizard`, which is bound to the `/wizard` Eyre endpoint, receives this request. `%wizard` responds to the HTTP request with a simple page containing a dropdown box of options.
- The user chooses an option, for instance, `%task-wizard`. An HTTP request is sent to `/wizard/task-wizard/~met/home/tasks`.
- `%wizard` receives this request, sees that the second iota specifies a wizard, and grabs that `manx` from the `(map stud manx)` it has in its state. It responds to the HTTP request with this `manx`.
- This `manx` contains a UI that helps the user create a child. This gets wrapped up into a `made` and sent to `/wizard/task-wizard/~met/home/tasks`.
- `%wizard` receives this post request, makes the shrub, and redirects the user to `/tree/~met/home/tasks/child`.

This `(map stud manx)` will need to get populated somehow, of course. Pokes could work, and seeing how software distribution works could be illuminating for the specifics here. 

Additionally, similar to tree, this would be even better if we could auto-filter down to only types of kids that are allowed to be created under a given shrub using a `%z` root dependency.