### PR TITLE
self: shrubs render themselves

### DIFF
--- a/pkg/arvo/app/neo.hoon
+++ b/pkg/arvo/app/neo.hoon
@@ -1573,6 +1573,8 @@
   =.  run
     (emit (do-card #/[p/our.bowl]/mast %make %mast ~ ~))
   =.  run
+    (emit (do-card #/[p/our.bowl]/self %make %self ~ ~))
+  =.  run
     (emit (do-card #/[p/our.bowl]/srv/tree %make %tree-eyre ~ (~(gas by *crew:neo) src/#/[p/our.bowl] ~)))
   run
   ++  pess  |=(=post:neo (~(pith press post) %out))

--- a/pkg/arvo/neo/cod/std/src/fil/s-k-y.js
+++ b/pkg/arvo/neo/cod/std/src/fil/s-k-y.js
@@ -592,7 +592,7 @@ class extends HTMLElement {
   }
   chooseStrategy(here) {
     let strats = this.defaultStrategies;
-    let strat = strats[here] || ['/tree'];
+    let strat = strats[here] || ['/self'];
     return strat[0];
   }
   renderIcon(name) {

--- a/pkg/arvo/neo/cod/std/src/fil/wi-nd.js
+++ b/pkg/arvo/neo/cod/std/src/fil/wi-nd.js
@@ -315,9 +315,14 @@ class extends HTMLElement {
     return JSON.parse(strats || '{}');
   }
   get strategies() {
-    return [...(this.getAttribute('strategies') || '').split(' ').map(m => {
-      return m.trim();
-    }).filter(f => !!f), '/tree'];
+    const userStrategies = (this.getAttribute('strategies') || '')
+      .split(' ')
+      .map(m => m.trim())
+      .filter(f => !!f);
+  
+    const uniqueStrategies = new Set([...userStrategies, '/hawk', '/tree', '/self']);
+  
+    return [...uniqueStrategies];
   }
   get strategyPoke() {
     let poke = {
@@ -337,8 +342,9 @@ class extends HTMLElement {
     //  ... eventually
     //
     return {
-      "/hawk": () => "htmx",
+      "/hawk": () => "hawk",
       "/tree": () => "tree",
+      "/self": () => "self",
       //
       "/mast": (x) => {
         let words = x.split("/").map(s => s.trim()).filter(s => !!s);
@@ -493,7 +499,7 @@ class extends HTMLElement {
     let menu = this.gid('menu');
     $(menu).children().remove();
     //
-    let top = $(`
+    /*let top = $(`
       <div class="fc g1">
         <span class="s-2 f3">renderer</span>
         <div class="fr g3 ac js">
@@ -521,8 +527,23 @@ class extends HTMLElement {
           </a>
         </div>
       </div>
+    `);*/
+    let top = $(`
+      <div class="fc g1">
+        <div class="fr g3 ac js">
+          <div class="grow"></div>
+          <a
+            href="${this.renderer}${this.here}"
+            class="p-1 s-1 f0 br1 bd2 b2 wfc fr ac js g1"
+            target="_blank"
+            >
+            <span>pop-out</span>
+            <span class="mso">arrow_outward</span>
+          </a>
+        </div>
+      </div>
     `);
-    $(top).find('h4').text(this.renderer);
+    /*$(top).find('h4').text(this.renderer);
     if (this.strategies.includes(this.renderer)) {
       $(top).find('#bm-save-btn').addClass('hidden')
     }
@@ -534,12 +555,12 @@ class extends HTMLElement {
     }
     $(top).find('#bm-del-btn').on('click', (e) => {
       $(this).emit('unbookmark-renderer', this.renderer)
-    });
-    menu.appendChild(top.get(0));
+    });*/
+    //menu.appendChild(top.get(0));
     //
     let bookmarks = $(`
       <div class="fc g1">
-        <span class="s-2 f3">bookmarks</span>
+        <span class="s-2 f3">renderers</span>
         <div class="frw g2 ac js">
         </div>
       </div>

--- a/pkg/arvo/neo/cod/std/src/imp/diary.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary.hoon
@@ -1,134 +1,209 @@
-/@  txt         ::  @t
-/@  diary       ::  name=@t
-/@  diary-diff  ::  ?([%put-entry id=@da =txt] [%del-entry id=@da])
-::
-::  outer core of a shrub: define state, pokes,
-::  dependencies, and kids
+/@  diary     
+/@  diary-diff
 ^-  kook:neo
 |%
-::
-::  diary's state is a %diary, just a @t
-++  state
-  ^-  curb:neo
-  [%pro %diary]
-::
-::  diary takes pokes with stud %diary-diff
-++  poke
-  ^-  (set stud:neo)
-  (sy %diary-diff ~)
-::
-::  constrain shrubs below diary in the namespace
-::  by defining the types of their state and pokes
+++  state  pro/%diary
+++  poke   (sy %diary-diff %eyre-task ~)
+++  deps  *deps:neo
 ++  kids
-  ::
-  ::  kids:neo is a (unit port:neo)
-  ^-  kids:neo
   %-  some
-  ::
-  ::  port:neo is (pair dare:neo lads:neo)
-  ::  dare:neo is ?(%y %z)
-  ::  if %y, only constrain our immediate children
-  ::  if %z, recursively constrain all descendants
   :-  %y
-  ::  lads:neo is (map pish:neo lash:neo)
   %-  ~(gas by *lads:neo)
-  :~  :-  ::
-          ::  pish:neo
-          ::  to simplify: [%.n @da] means the kid's
-          ::  path contains any @da, and %.n is there
-          ::  to signify that the pith can not have more
-          ::  fields afterwards
-          [[%.n %da] %.y]
-      ::
-      ::  lash:neo is (pair curb:neo (set stud:neo))
-      ::  curb:neo defines the kids' state
-      ::  (set stud:neo) defines the kids' pokes
-      [[%only %txt] ~]
+  :~  :-  [|/da &]
+      [only/%txt ~]
   ==
 ::
-::  diary has no other shrubs as dependencies
-++  deps
-  ^-  deps:neo
-  *deps:neo
-::
-::  inner core, business logic
 ++  form
   ^-  form:neo
+  =<
   |_  [=bowl:neo =aeon:neo =pail:neo]
-  ::
-  ::  if diary has no existing state, return
-  ::  the bunt of the state type, otherwise
-  ::  return the existing state
+  +*  web  ~(. +> [bowl pail])
   ++  init
     |=  old=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
     :-  ~
     ?~  old
-      [%diary !>(*diary)]
+      diary/!>(*diary)
     u.old
   ::
   ++  poke
     |=  [=stud:neo vax=vase]
     ^-  (quip card:neo pail:neo)
-    ?>  =(%diary p.pail)
-    ?>  =(%diary-diff stud)
-    =/  state  !<(diary q.pail)
-    =/  act    !<(diary-diff vax)
-    ::
-    ::  assert the poke comes from our ship
-    ::  src.bowl:neo is (pair ship pith)
     ?>  =(our ship.src):bowl
-    ?-    -.act
-       %put-entry
-      ::   return unchanged state
-      :_  [%diary !>(state)]
-      ::
-      ::  create list of one card:neo
-      ::  card:neo is (pair pith:neo note:neo)
-      :~  :-  %+  welp
-                ::
-                ::  here.bowl is the path of this shrub
-                ::  /path/to/diary
-                here.bowl
-              ::
-              ::  append post id
-              ::  /path/to/diary/~2024.6.3..14.07.15..7098
-              ~[[%da id.act]]
-          ::
-          ::  this note will %make a new shrub
-          ::  at the pith we defined above
-          ^-  note:neo
-          ::  [%make stud:neo (unit pail:neo) conf:neo]
-          :*  %make
-              ::
-              ::  new shrub has the implementation %txt
-              ::  see /imp/txt.hoon, a stub that allows
-              ::  you to create a %txt in the namespace
-              %txt
-              ::
-              ::  new shrub's initial state
-              ::  is the text from the poke
-              `[%txt !>(txt.act)]
-              ::
-              ::  conf:neo is (map term pith:neo)
-              ::  declare this new shrub's dependencies
-              ::  which are also shrubs; diary has none
-              ~
-          ==
-      ==
-    ::
-        %del-entry
-      ::  return unchanged state
-      :_  [%diary !>(state)]
-      ::
-      ::  send a %cull note to /path/to/diary/<id>
-      ::  this will delete the diary entry.
-      :~  :-  %+  welp
-                here.bowl
-              ~[[%da id.act]]
-          ^-  note:neo
-          [%cull ~]
+    ?+    stud
+        %eyre-task
+      (eyre-handler:web !<(=task:eyre:neo vase))
+        %diary-diff
+      =/  act  !<(diary-diff vax)
+      :_  pail
+      :-  (welp here.bowl ~[[%da id.act]])
+      ?-  -.act
+        %put-entry  [%make %txt `[%txt !>(txt.act)] ~]~
+        %del-entry  [%cull ~]~
       ==
     ==
+  --
+  ::  XX turn this all into a library, make it easy and beautiful
+  |_  [=bowl:neo =pail:neo]
+  ++  eyre-handler
+    |=  =task:eyre:neo
+    ^-  (quip card:neo pail:neo)
+    :_  pail
+    =/  [eyre-id=@ta req=inbound-request:eyre]  task
+    ?+    method.request.req  
+        ~|(%unsupported-http-method !!)
+    ::
+        %'GET'
+      (eyre-cards task)
+    ::
+        %'POST'
+      =;  poke
+        [here.bowl %poke [%diary-diff !>(poke)]]~
+      ^-  diary-diff
+      =/  body  (parse-body:serv request.req)
+      =/  mu  ~(. manx-utils body)
+      =/  head  (@tas (got:mu %head))
+      ?+    head  !!
+          %put-entry
+        =/  text  (vol:mu "text")
+        [%put-entry now.bowl text]
+      ::
+          %del-entry
+        [%del-entry (slav %da (got:mu %diary-id))]
+      ==
+    ==
+  ::
+  ++  eyre-cards
+    |=  [eyre-id=@ta req=inbound-request:eyre]
+    :~  (head-card eyre-id)
+    ::
+        :*  #/[p/our.bowl]/$/eyre
+            %poke
+            %eyre-sign
+            !>
+            :+  eyre-id
+              %data
+            :-  ~
+            %-  manx-to-octs
+            %-  render
+            (pave:neo pax:(parse-url-frfr:serv request.req))
+        ==
+    ::
+        (done-card eyre-id)
+    ==
+  ::
+  ++  head-card
+    |=  eyre-id=@ta
+    :*  #/[p/our.bowl]/$/eyre
+        %poke
+        %eyre-sign
+        !>([eyre-id %head 200 ['content-type' 'text/html']~])
+    ==
+  ::
+  ++  done-card
+    |=  eyre-id=@ta
+    :*  #/[p/our.bowl]/$/eyre 
+        %poke 
+        %eyre-sign
+        !>([eyre-id %done ~])
+    ==
+  ::
+  ++  render
+    |=  name=pith
+    ^-  manx
+    ;html
+      ;head
+        ;*  old-standard-head-tags:serv
+        ;*  standard-head-tags:serv
+      ==
+      ;body
+        =hx-ext  "dom-enc"
+        ;main.p-page.mw-page.ma.fc.g5
+          ;h1.bold.f-2: BLUE
+          ;+  diary-form
+          ;+  diary-items
+          ;+  refresher
+        ==
+      ==
+    ==
+  ::
+  ++  diary-form
+    ;form.fc.g2.as
+      =hx-post       (en-tape:pith:neo name)
+      =hx-target     "closest .p-page"
+      =hx-select     ".p-page"
+      =hx-swap       "outerHTML"
+      =head          "put-entry"
+      ;textarea.p2.bd1.br1.wf
+        =name  "text"
+        =placeholder  "today, i ..."
+        =oninput  "this.setAttribute('value', this.value)"
+        =rows  "5"
+        =required  ""
+        =autocomplete  "off"
+        ;
+      ==
+      ;button.p2.b1.br1.bd1.wfc.hover.loader
+        ;span.loaded: create
+        ;span.loading
+          ;+  loading.feather-icons
+        ==
+      ==
+    ==
+  ::
+  ++  diary-items
+    ;div#items.fc.g2
+      ;*
+      %-  turn
+      :_  link-entry
+      %+  sort
+        %~  tap
+          of:neo
+        %.  /
+        %~  del
+          of:neo
+        q:(~(got by deps.bowl) %src)
+      |=  [a=[=pith *] b=[=pith *]]
+      (gth ->.pith.a ->.pith.b)
+    ==
+    ::
+  ++  link-entry
+    |=  [pax=pith =idea:neo]
+    =/  tape  (trip !<(@t q.q.saga.idea))
+    ;div.fr.g2
+      ;div.fc.g1.grow.br1.p-2.b1
+        ;span.f3: {(pretty-date `@da`->:pax)}
+        ;span.bold: {tape}
+      ==
+      ;button.p2.br1.b1.hover.loader
+        =hx-post  (en-tape:pith:neo name)
+        =head          "del-entry"
+        =hx-target     "closest .p-page"
+        =hx-select     ".p-page"
+        =hx-swap  "outerHTML"
+        =diary-id  (trip (snag 0 (pout pax)))
+        ;span.loaded
+          ;+  close.feather-icons
+        ==
+        ;span.loading
+          ;+  loading.feather-icons
+        ==
+      ==
+    ==
+  ++  refresher
+    ;div
+      =hx-get  (en-tape:pith:neo name)
+      =hx-target     "#items"
+      =hx-select     "#items"
+      =hx-swap       "outerHTML"
+      =hx-trigger    "every 10s"
+      ;
+    ==
+  ::
+  ++  pretty-date
+    |=  date=@da
+    ^-  tape
+    =/  d  (yore date)
+    "{(y-co:co y:d)}-{(y-co:co m:d)}-{(y-co:co d:t:d)}"
   --
 --

--- a/pkg/arvo/neo/cod/std/src/imp/diary.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/diary.hoon
@@ -1,5 +1,8 @@
 /@  diary     
 /@  diary-diff
+/-  oxy=oxygen
+/-  feather-icons
+/-  serv=sky-server
 ^-  kook:neo
 |%
 ++  state  pro/%diary
@@ -9,7 +12,7 @@
   %-  some
   :-  %y
   %-  ~(gas by *lads:neo)
-  :~  :-  [|/da &]
+  :~  :-  [|/%da &]
       [only/%txt ~]
   ==
 ::
@@ -21,7 +24,7 @@
   ++  init
     |=  old=(unit pail:neo)
     ^-  (quip card:neo pail:neo)
-    :-  ~
+    :-  [(bind:oxy bowl) ~]
     ?~  old
       diary/!>(*diary)
     u.old
@@ -30,38 +33,46 @@
     |=  [=stud:neo vax=vase]
     ^-  (quip card:neo pail:neo)
     ?>  =(our ship.src):bowl
-    ?+    stud
+    ?+    stud  !!
         %eyre-task
-      (eyre-handler:web !<(=task:eyre:neo vase))
+      (handle:web !<(task:eyre:neo vax))
         %diary-diff
       =/  act  !<(diary-diff vax)
       :_  pail
-      :-  (welp here.bowl ~[[%da id.act]])
-      ?-  -.act
-        %put-entry  [%make %txt `[%txt !>(txt.act)] ~]~
-        %del-entry  [%cull ~]~
+      :~  ?-    -.act
+              %put-entry  
+            :-  (welp here.bowl [[%da id.act] ~])
+            [%make %txt `[%txt !>(txt.act)] ~]
+          ::
+              %del-entry  
+            :-  (welp here.bowl [[%da id.act] ~])
+            [%cull ~]
+          ==
       ==
     ==
   --
-  ::  XX turn this all into a library, make it easy and beautiful
+  ::
   |_  [=bowl:neo =pail:neo]
-  ++  eyre-handler
-    |=  =task:eyre:neo
+  ++  handle
+    |=  [eyre-id=@ta req=inbound-request:eyre]
     ^-  (quip card:neo pail:neo)
     :_  pail
-    =/  [eyre-id=@ta req=inbound-request:eyre]  task
     ?+    method.request.req  
         ~|(%unsupported-http-method !!)
     ::
         %'GET'
-      (eyre-cards task)
+      =;  manx
+        (respond:oxy [bowl eyre-id req manx])
+      %~  render
+        ui
+      (pave:neo pax:(parse-url:oxy request.req))
     ::
         %'POST'
       =;  poke
         [here.bowl %poke [%diary-diff !>(poke)]]~
       ^-  diary-diff
-      =/  body  (parse-body:serv request.req)
-      =/  mu  ~(. manx-utils body)
+      =/  body  (parse-body:oxy request.req)
+      =/  mu  ~(. manx-utils:oxy body)
       =/  head  (@tas (got:mu %head))
       ?+    head  !!
           %put-entry
@@ -73,137 +84,102 @@
       ==
     ==
   ::
-  ++  eyre-cards
-    |=  [eyre-id=@ta req=inbound-request:eyre]
-    :~  (head-card eyre-id)
-    ::
-        :*  #/[p/our.bowl]/$/eyre
-            %poke
-            %eyre-sign
-            !>
-            :+  eyre-id
-              %data
-            :-  ~
-            %-  manx-to-octs
-            %-  render
-            (pave:neo pax:(parse-url-frfr:serv request.req))
+  ++  ui
+    |_  here=pith
+    ++  render
+      ^-  manx
+      ;html
+        ;head
+          ;*  old-standard-head-tags:serv
+          ;*  standard-head-tags:serv
         ==
-    ::
-        (done-card eyre-id)
-    ==
-  ::
-  ++  head-card
-    |=  eyre-id=@ta
-    :*  #/[p/our.bowl]/$/eyre
-        %poke
-        %eyre-sign
-        !>([eyre-id %head 200 ['content-type' 'text/html']~])
-    ==
-  ::
-  ++  done-card
-    |=  eyre-id=@ta
-    :*  #/[p/our.bowl]/$/eyre 
-        %poke 
-        %eyre-sign
-        !>([eyre-id %done ~])
-    ==
-  ::
-  ++  render
-    |=  name=pith
-    ^-  manx
-    ;html
-      ;head
-        ;*  old-standard-head-tags:serv
-        ;*  standard-head-tags:serv
-      ==
-      ;body
-        =hx-ext  "dom-enc"
-        ;main.p-page.mw-page.ma.fc.g5
-          ;h1.bold.f-2: BLUE
-          ;+  diary-form
-          ;+  diary-items
-          ;+  refresher
+        ;body
+          =hx-ext  "dom-enc"
+          ;main.p-page.mw-page.ma.fc.g5
+            ;h1.bold.f-3: Diary
+            ;+  diary-form
+            ;+  diary-items
+            ;+  refresher
+          ==
         ==
       ==
-    ==
-  ::
-  ++  diary-form
-    ;form.fc.g2.as
-      =hx-post       (en-tape:pith:neo name)
-      =hx-target     "closest .p-page"
-      =hx-select     ".p-page"
-      =hx-swap       "outerHTML"
-      =head          "put-entry"
-      ;textarea.p2.bd1.br1.wf
-        =name  "text"
-        =placeholder  "today, i ..."
-        =oninput  "this.setAttribute('value', this.value)"
-        =rows  "5"
-        =required  ""
-        =autocomplete  "off"
-        ;
-      ==
-      ;button.p2.b1.br1.bd1.wfc.hover.loader
-        ;span.loaded: create
-        ;span.loading
-          ;+  loading.feather-icons
-        ==
-      ==
-    ==
-  ::
-  ++  diary-items
-    ;div#items.fc.g2
-      ;*
-      %-  turn
-      :_  link-entry
-      %+  sort
-        %~  tap
-          of:neo
-        %.  /
-        %~  del
-          of:neo
-        q:(~(got by deps.bowl) %src)
-      |=  [a=[=pith *] b=[=pith *]]
-      (gth ->.pith.a ->.pith.b)
-    ==
     ::
-  ++  link-entry
-    |=  [pax=pith =idea:neo]
-    =/  tape  (trip !<(@t q.q.saga.idea))
-    ;div.fr.g2
-      ;div.fc.g1.grow.br1.p-2.b1
-        ;span.f3: {(pretty-date `@da`->:pax)}
-        ;span.bold: {tape}
-      ==
-      ;button.p2.br1.b1.hover.loader
-        =hx-post  (en-tape:pith:neo name)
-        =head          "del-entry"
+    ++  diary-form
+      ;form.fc.g2.as
+        =hx-post       (en-tape:pith:neo here)
         =hx-target     "closest .p-page"
         =hx-select     ".p-page"
-        =hx-swap  "outerHTML"
-        =diary-id  (trip (snag 0 (pout pax)))
-        ;span.loaded
-          ;+  close.feather-icons
+        =hx-swap       "outerHTML"
+        =head          "put-entry"
+        ;textarea.p2.bd1.br1.wf
+          =name  "text"
+          =placeholder  "today, i ..."
+          =oninput  "this.setAttribute('value', this.value)"
+          =rows  "5"
+          =required  ""
+          =autocomplete  "off"
+          ;
         ==
-        ;span.loading
-          ;+  loading.feather-icons
+        ;button.p2.b1.br1.bd1.wfc.hover.loader
+          ;span.loaded: create
+          ;span.loading
+            ;+  loading.feather-icons
+          ==
         ==
       ==
-    ==
-  ++  refresher
-    ;div
-      =hx-get  (en-tape:pith:neo name)
-      =hx-target     "#items"
-      =hx-select     "#items"
-      =hx-swap       "outerHTML"
-      =hx-trigger    "every 10s"
-      ;
-    ==
-  ::
-  ++  pretty-date
-    |=  date=@da
-    ^-  tape
-    =/  d  (yore date)
-    "{(y-co:co y:d)}-{(y-co:co m:d)}-{(y-co:co d:t:d)}"
+    ::
+    ++  diary-items
+      ;div#items.fc.g2
+        ;*
+        %-  turn
+        :_  link-entry
+        %+  sort
+          %~  tap
+            of:neo
+          (~(del of:neo kids.bowl) /)
+        |=  [a=[=pith *] b=[=pith *]]
+        (gth ->.pith.a ->.pith.b)
+      ==
+    ::
+    ++  link-entry
+      |=  [pax=pith =idea:neo]
+      =/  tape  (trip !<(@t q.q.saga.idea))
+      ;div.fr.g2
+        ;div.fc.g1.grow.br1.p-2.b1
+          ;span.f3: {(pretty-date `@da`->:pax)}
+          ;span.bold: {tape}
+        ==
+        ;button.p2.br1.b1.hover.loader
+          =hx-post  (en-tape:pith:neo here)
+          =head          "del-entry"
+          =hx-target     "closest .p-page"
+          =hx-select     ".p-page"
+          =hx-swap  "outerHTML"
+          =diary-id  (trip (snag 0 (pout pax)))
+          ;span.loaded
+            ;+  close.feather-icons
+          ==
+          ;span.loading
+            ;+  loading.feather-icons
+          ==
+        ==
+      ==
+    ::
+    ++  refresher
+      ;div
+        =hx-get  (en-tape:pith:neo here)
+        =hx-target     "#items"
+        =hx-select     "#items"
+        =hx-swap       "outerHTML"
+        =hx-trigger    "every 10s"
+        ;
+      ==
+    ::
+    ++  pretty-date
+      |=  date=@da
+      ^-  tape
+      =/  d  (yore date)
+      "{(y-co:co y:d)}-{(y-co:co m:d)}-{(y-co:co d:t:d)}"
+    --
   --
 --

--- a/pkg/arvo/neo/cod/std/src/imp/self.hoon
+++ b/pkg/arvo/neo/cod/std/src/imp/self.hoon
@@ -1,0 +1,33 @@
+/-  oxy=oxygen
+^-  kook:neo
+|%
+++  state  pro/%sig
+++  poke   (sy %eyre-task ~)
+++  kids  *kids:neo
+++  deps  *deps:neo
+++  form
+  |_  [=bowl:neo =aeon:neo =pail:neo]
+  ++  init
+    |=  pal=(unit pail:neo)
+    :_  sig/!>(~)
+    =/  =pith:neo  #/[p/our.bowl]/$/eyre
+    :~  [pith %poke eyre-req/!>([%connect [~ ~[%self]] here.bowl])]
+    ==
+  ++  poke
+    |=  [=stud:neo vax=vase]
+    ^-  (quip card:neo pail:neo)
+    ?+    stud  ~|(bad-stud/stud !!)
+        %eyre-task
+      =+  !<(=task:eyre:neo vax)
+      =/  [eyre-id=@ta req=inbound-request:eyre]  task
+      =/  inner=pith:neo
+        (pave:neo pax:(parse-url:oxy request.req))
+      :_  sig/!>(~)
+      :~  :*  (slag 1 inner)  :: /self/pith
+              %poke
+              [%eyre-task !>(task)]
+          ==
+      ==
+    ==
+  --
+--

--- a/pkg/arvo/neo/cod/std/src/lib/oxygen.hoon
+++ b/pkg/arvo/neo/cod/std/src/lib/oxygen.hoon
@@ -1,0 +1,51 @@
+/-  manx-utils
+::  Oxygen - a library for Eyre
+|%
+++  bind
+  |=  =bowl:neo
+  ^-  card:neo
+  =/  path  (pout here.bowl)
+  :*  #/[p/our.bowl]/$/eyre
+      %poke 
+      eyre-req/!>([%connect [~ path] here.bowl])
+  ==
+::
+++  respond
+  |=  [=bowl:neo eyre-id=@ta req=inbound-request:eyre =manx]
+  ^-  (list card:neo)
+  %+  turn
+    :~  !>([eyre-id %head 200 ['content-type' 'text/html']~])
+        !>([eyre-id %data `(manx-to-octs manx)])
+        !>([eyre-id %done ~])
+    ==
+  |=  =vase
+  :*  #/[p/our.bowl]/$/eyre
+      %poke
+      %eyre-sign
+      vase
+  ==
+::
+++  parse-url
+  |=  =request:http
+  ^-  [pax=path pam=(map @t @t)]
+  =/  parsed
+    %+  rash  url.request
+    ;~  plug
+        ;~(pfix fas (more fas smeg:de-purl:html))
+        yque:de-purl:html
+    ==
+  :-  -.parsed
+  (~(uni by (malt +.parsed)) (malt header-list.request))
+::
+++  parse-body
+  |=  =request:http
+  ^-  manx
+  %+  fall
+    (de-xml:html q:(fall body.request [p=0 q='']))
+  *manx
+::
+++  manx-to-octs
+  |=  man=manx
+  ^-  octs
+  (as-octt:mimes:html (en-xml:html man))
+--


### PR DESCRIPTION
`blue` is good for overlays

`mast` is good for recursive rendering

`???` is good for non-overlay, non-recursive rendering

Add a third rendering methodology, `self`, which simply passes http requests to the shrub specified in the path. If Sky doesn't know about any other strategies for this path (which will typically be the case), it should use `self` as the default rendering framework.