### PR TITLE
Change +kids:of return type to axal

### DIFF
--- a/pkg/arvo/neo/cod/std/src/fil/axal.txt
+++ b/pkg/arvo/neo/cod/std/src/fil/axal.txt
@@ -143,12 +143,12 @@ Get the kids of the node at the given path.
 ```
 ++  kids
   |=  pax=pith
-  ^-  (axil _?>(?=(^ fil.fat) u.fil.fat))
+  ^-  (axal _?>(?=(^ fil.fat) u.fil.fat))
   :-  (get pax)
   (kid pax)
 ```
 
-Returns an [`axil`](https://docs.urbit.org/language/hoon/reference/arvo#axil), for secret reasons.
+Returns an axal.
 
 ## `+lop`
 

--- a/pkg/arvo/sur/neo.hoon
+++ b/pkg/arvo/sur/neo.hoon
@@ -203,7 +203,7 @@
   ::
   ++  kids
     |=  pax=pith
-    ^-  (axil _?>(?=(^ fil.fat) u.fil.fat))
+    ^-  (axal _?>(?=(^ fil.fat) u.fil.fat))
     :-  (get pax)
     (kid pax)
   ::


### PR DESCRIPTION
`+kids:of` is unique in the `+of` core in that it's the only arm that returns an `+axil`, rather than an `+axal`. This arm isn't used anywhere, so there's no cost to changing it. Changing this means we can more easily run `+tap:of` and `+tar:of` to serialize a relevant map-like subtree in our kids or dependencies.